### PR TITLE
Add `open` attribute to markers

### DIFF
--- a/components/map-marker.js
+++ b/components/map-marker.js
@@ -193,6 +193,7 @@ export default class HTMLMapMarkerElement extends HTMLElement {
 						} else if (! this.open && marker.isPopupOpen()) {
 							marker.closePopup();
 						}
+						this.dispatchEvent(new Event(this.open ? 'open' : 'close'));
 					});
 				}
 				break;

--- a/components/map-marker.js
+++ b/components/map-marker.js
@@ -188,12 +188,16 @@ export default class HTMLMapMarkerElement extends HTMLElement {
 				if (this._map instanceof HTMLElement) {
 					this._map.ready.then(() => {
 						const marker = map.get(this);
-						if (this.open && ! marker.isPopupOpen()) {
+						const open = this.open;
+						const isOpen = marker.isPopupOpen();
+
+						if (open && ! isOpen) {
 							marker.openPopup();
-						} else if (! this.open && marker.isPopupOpen()) {
+						} else if (! open && isOpen) {
 							marker.closePopup();
 						}
-						this.dispatchEvent(new Event(this.open ? 'open' : 'close'));
+
+						this.dispatchEvent(new Event(open ? 'open' : 'close'));
 					});
 				}
 				break;

--- a/components/open-street-map.html
+++ b/components/open-street-map.html
@@ -25,6 +25,7 @@
 	</head>
 	<body>
 		<slot name="map">
+			<!-- Be sure to load Leaflet CSS if assigning this slot -->
 			<div id="map-fallback"></div>
 		</slot>
 		<slot name="attribution">


### PR DESCRIPTION
Toggling changes display of popup

```html
<open-street-map center="35.756003,-118.4206114" zoom="15" zoomcontrol="">
	<map-marker slot="markers" longitude="-118.4206114" latitude="35.756003" title="Kernville Cowork" itemtype="https://schema.org/Organization" itemscope="" open="">
		<img src="/img/octicons/organization.svg" width="32" height="32" slot="icon" />
		<div slot="popup">
			<h4 itemprop="name">Kernville Cowork</h4>
			<img itemprop="image" src="https://lh5.googleusercontent.com/p/AF1QipMxQJcb7_090Gkke0WPu92xeXgl_zdLS9XtC8BI=w203-h152-k-no" crossorigin="anonymous" />
			<hr />
			<address itemprop="address" itemtype="https://schema.org/PostalAddress" itemscope="">
				<div itemprop="streetAddress">21 Sierra Dr.</div>
				<div itemprop="postOfficeBoxNumber">Box 1417</div>
				<div>
					<span itemprop="addressRegion">Kernville</span>,
					<span itemprop="addressLocality">CA</span>
					<span itemprop="postalCode">93238</span>
				</div>
			</address>
			<blockquote itemprop="description">Kernville Cowork's vision is to: * Create a community for collaboration, innovation, and continuous learning * Create a pathway for local students to become interested and get involved with careers in technology that they can utilize while staying in the valley * Create a destination for skilled distributed workers that have a desire to live and work in a small thriving community with access to outdoor adventure.</blockquote>
			<a itemprop="url" href="https://kernvillecowork.com/en" rel="noopener external">Website</a>
			<br />
			<a itemprop="telephone" href="tel:+1-760-549-0423">760 549-0423</a>
		</div>
	</map-marker>
</open-street-map>
```