### PR TITLE
Extend Leaflet functionality (breaking)

### DIFF
--- a/components/leaflet/geojson.js
+++ b/components/leaflet/geojson.js
@@ -112,9 +112,11 @@ customElements.define('leaflet-geojson', class HTMLLeafletGeoJSONElement extends
 	}
 
 	async connectedCallback() {
-		if (this.parentElement.tagName === 'LEAFLET-MAP') {
-			this._map = this.parentElement;
-			await this._map.ready;
+		const closestMap = this.closest('leaflet-map');
+		if (closestMap instanceof HTMLElement) {
+			await customElements.whenDefined('leaflet-map');
+			await closestMap.ready;
+			this._map = closestMap;
 
 			if (! map.has(this)) {
 				map.set(this, await this._make());

--- a/components/leaflet/image-overlay.js
+++ b/components/leaflet/image-overlay.js
@@ -12,8 +12,11 @@ customElements.define('leaflet-image-overlay', class HTMLLeafletImageOverlayElem
 	}
 
 	async connectedCallback() {
-		if (this.parentElement.tagName === 'LEAFLET-MAP') {
-			this._map = this.parentElement;
+		const closestMap = this.closest('leaflet-map');
+		if (closestMap instanceof HTMLElement) {
+			await customElements.whenDefine('leaflet-map');
+			await closestMap.ready;
+			this._map = closestMap;
 
 			if (! map.has(this)) {
 				map.set(this, await this._make());

--- a/components/leaflet/map.js
+++ b/components/leaflet/map.js
@@ -22,9 +22,6 @@ customElements.define('leaflet-map', class HTMLLeafletMapElement extends HTMLEle
 			this._shadow.append(...doc.head.children, ...doc.body.children);
 			this.dispatchEvent(new Event('populated'));
 		});
-
-		this._populated.then(() => console.info('populated'));
-		this.ready.then(() => console.info('ready'));
 	}
 
 	async connectedCallback() {
@@ -48,6 +45,8 @@ customElements.define('leaflet-map', class HTMLLeafletMapElement extends HTMLEle
 
 		LeafletTileLayer(this.tileSrc, {
 			attribution: this.attribution,
+			crossOrigin: this.crossOrigin,
+			detectRetina: this.detectRetina,
 			minZoom: this.minZoom,
 			maxZoom: this.maxZoom,
 			label: 'OpenStreetMap',
@@ -87,6 +86,22 @@ customElements.define('leaflet-map', class HTMLLeafletMapElement extends HTMLEle
 				resolve(this);
 			}
 		});
+	}
+
+	get crossOrigin() {
+		return this.getAttribute('crossorigin') || 'annonymous';
+	}
+
+	set crossOrigin(val) {
+		this.setAttribute('crossorigin', val);
+	}
+
+	get detectRetina() {
+		return this.hasAttribute('detectretina');
+	}
+
+	set detectRetina(val) {
+		this.toggleAttribute('detectretina', val);
 	}
 
 	get zoom() {
@@ -152,7 +167,7 @@ customElements.define('leaflet-map', class HTMLLeafletMapElement extends HTMLEle
 	get tileSrc() {
 		/* https://{s}.tile.openstreetmap.org/{z}/{x}/{y}{r}.png */
 		/* https://maps.wikimedia.org/osm-intl/{z}/{x}/{y}{r}.png */
-		return this.getAttribute('tilesrc') || 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}{r}.png';
+		return this.getAttribute('tilesrc') || HTMLLeafletMapElement.wikimedia;
 	}
 
 	get attribution() {
@@ -325,5 +340,13 @@ customElements.define('leaflet-map', class HTMLLeafletMapElement extends HTMLEle
 			'zoom',
 			'center',
 		];
+	}
+
+	static get wikimedia() {
+		return 'https://maps.wikimedia.org/osm-intl/{z}/{x}/{y}{r}.png';
+	}
+
+	static get osm() {
+		return 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}{r}.png';
 	}
 });

--- a/components/leaflet/map.js
+++ b/components/leaflet/map.js
@@ -1,12 +1,8 @@
 // @TODO Only import what is needed from Leaflet
 import * as Leaflet from 'https://unpkg.com/leaflet@1.6.0/dist/leaflet-src.esm.js';
-import './marker.js';
-import './image-overlay.js';
-import './geojson.js';
 import { getLocation } from '../../js/std-js/functions.js';
 
 let map = new Map();
-
 
 /**
  * @see https://leafletjs.com/reference-1.5.0.html#map-factory
@@ -152,7 +148,9 @@ customElements.define('leaflet-map', class HTMLLeafletMapElement extends HTMLEle
 	}
 
 	get tileSrc() {
-		return this.getAttribute('tilesrc') || 'https://maps.wikimedia.org/osm-intl/{z}/{x}/{y}{r}.png';
+		/* https://{s}.tile.openstreetmap.org/{z}/{x}/{y}{r}.png */
+		/* https://maps.wikimedia.org/osm-intl/{z}/{x}/{y}{r}.png */
+		return this.getAttribute('tilesrc') || 'https://{s}.tile.openstreetmap.org/{z}/{x}/{y}{r}.png';
 	}
 
 	get attribution() {

--- a/components/leaflet/map.js
+++ b/components/leaflet/map.js
@@ -1,6 +1,8 @@
-// @TODO Only import what is needed from Leaflet
-import * as Leaflet from 'https://unpkg.com/leaflet@1.6.0/dist/leaflet-src.esm.js';
 import { getLocation } from '../../js/std-js/functions.js';
+import {
+	map as LeafletMap,
+	tileLayer as LeafletTileLayer
+} from 'https://unpkg.com/leaflet@1.6.0/dist/leaflet-src.esm.js';
 
 let map = new Map();
 
@@ -27,7 +29,7 @@ customElements.define('leaflet-map', class HTMLLeafletMapElement extends HTMLEle
 
 	async connectedCallback() {
 		await this._populated;
-		const m = Leaflet.map(this.mapElement, {
+		const m = LeafletMap(this.mapElement, {
 			zoomControl: this.zoomControl,
 			tap: false,
 		});
@@ -44,7 +46,7 @@ customElements.define('leaflet-map', class HTMLLeafletMapElement extends HTMLEle
 			m.setView([33.811137945997444, -117.91675329208375], this.zoom);
 		}
 
-		Leaflet.tileLayer(this.tileSrc, {
+		LeafletTileLayer(this.tileSrc, {
 			attribution: this.attribution,
 			minZoom: this.minZoom,
 			maxZoom: this.maxZoom,

--- a/components/leaflet/marker.js
+++ b/components/leaflet/marker.js
@@ -151,6 +151,17 @@ customElements.define('leaflet-marker', class HTMLLeafletMarkerElement extends H
 
 	_make() {
 		const {latitude, longitude, title, iconImg, popup} = this;
+		const eventDispatcher = ({containerPoint, latlng, originalEvent, type}) => {
+			this.dispatchEvent(new CustomEvent(`marker${type}`, {detail: {
+				coordinates: {
+					latitude: latlng.lat,
+					longitude: latlng.lng,
+					x: containerPoint.x,
+					y: containerPoint.y,
+				},
+				originalEvent,
+			}}));
+		};
 		let m;
 
 		if (iconImg instanceof HTMLImageElement) {
@@ -161,6 +172,14 @@ customElements.define('leaflet-marker', class HTMLLeafletMarkerElement extends H
 		} else {
 			m = marker([latitude, longitude], {title});
 		}
+
+		m.on('click', eventDispatcher);
+		m.on('dblclick', eventDispatcher);
+		m.on('mousedown', eventDispatcher);
+		m.on('mouseup', eventDispatcher);
+		m.on('mouseover', eventDispatcher);
+		m.on('mouseout', eventDispatcher);
+		m.on('contextmenu', eventDispatcher);
 
 		if (popup instanceof HTMLElement) {
 			m.bindPopup(popup);

--- a/components/leaflet/marker.js
+++ b/components/leaflet/marker.js
@@ -38,18 +38,19 @@ customElements.define('leaflet-marker', class HTMLLeafletMarkerElement extends H
 	}
 
 	async connectedCallback() {
-		if (this.parentElement.tagName === 'LEAFLET-MAP') {
-			this._map = this.parentElement;
-			await this._map.ready;
+		const closestMap = this.closest('leaflet-map');
+		if (closestMap instanceof HTMLElement) {
+			await customElements.whenDefined('leaflet-map');
+			const mapEl = await closestMap.ready;
+			this._map = closestMap;
 
 			if (! map.has(this)) {
 				map.set(this, await this._make());
 			}
 
 			if (! this.hidden) {
-				await this._map.ready;
 				const marker = map.get(this);
-				marker.addTo(this._map.map);
+				marker.addTo(mapEl.map);
 
 				if (this.open) {
 					setTimeout(() => marker.openPopup(), 500);
@@ -199,7 +200,7 @@ customElements.define('leaflet-marker', class HTMLLeafletMarkerElement extends H
 				if (this.hidden) {
 					marker.remove();
 				} else if (this._map instanceof HTMLElement) {
-					this._map.ready.then(el => marker.addTo(el.map));
+					this._map.ready.then(() => marker.addTo(this._map.map));
 				}
 				break;
 

--- a/components/network-offline.js
+++ b/components/network-offline.js
@@ -1,0 +1,8 @@
+customElements.define('network-offline', class HTMLNetworkOfflineElement extends HTMLElement {
+	constructor() {
+		super();
+		this.hidden = navigator.onLine;
+		window.addEventListener('online', () => this.hidden = true);
+		window.addEventListener('offline', () => this.hidden = false);
+	}
+});

--- a/components/network-online.js
+++ b/components/network-online.js
@@ -1,0 +1,8 @@
+customElements.define('network-online', class HTMLNetworkOfflineElement extends HTMLElement {
+	constructor() {
+		super();
+		this.hidden = !navigator.onLine;
+		window.addEventListener('online', () => this.hidden = false);
+		window.addEventListener('offline', () => this.hidden = true);
+	}
+});

--- a/components/not-supported.js
+++ b/components/not-supported.js
@@ -1,0 +1,10 @@
+customElements.define('not-supported', class HTMLNotSupportedElement extends HTMLElement
+{
+	/**
+	 * If custom elements are supported, as evidenced by this method being called,
+	 * simply remove the element.
+	 */
+	connectedCallback() {
+		this.remove();
+	}
+});


### PR DESCRIPTION
## Add leaflet event dispatching to markers and do not import anything unnecessary

Projects will need to import the necessary components, including map, marker, etc.

### List of significant changes made
- Do not import anything else into `<leaflet-map>`
- Dispatch click, dblclick, etc. events for markers
- Add `<not-supported>` element for when custom elements are not supported
- Add network status elements (online & offline) to be shown/hidden depending on network status
- Add crossOrigin & detectRetina support via attributes
- Add preset tile srcs via static get methods
- Do not require direct descent from `<leaflet-map>`
- Wait for `<leaflet-map>` definition & `ready` Promises
