### PR TITLE
Fix visibility of share button

### DIFF
--- a/components/share-button.js
+++ b/components/share-button.js
@@ -1,4 +1,5 @@
 import webShareApi from '/js/std-js/webShareApi.js';
+import { loaded } from '/js/std-js/functions.js';
 import {
 	facebook,
 	twitter,
@@ -15,7 +16,9 @@ webShareApi(facebook, twitter, googlePlus, linkedIn, reddit, gmail, email, clipb
 export default class HTMLShareButtonElement extends HTMLButtonElement {
 	constructor() {
 		super();
-		this.hidden = !(navigator.share instanceof Function);
+
+		loaded().then(() => this.hidden = !(navigator.share instanceof Function));
+
 		this.addEventListener('click', async event => {
 			event.preventDefault();
 			event.stopPropagation();


### PR DESCRIPTION
Constructor was setting visibility before shim had chance to be applied.