### PR TITLE
Add Netlify build status badge to README.md

### DIFF
--- a/.github/ISSUE_TEMPLATE/bug_report.md
+++ b/.github/ISSUE_TEMPLATE/bug_report.md
@@ -3,7 +3,6 @@ name: Bug report
 about: Create a report to help us improve
 title: Report a bug
 labels: bug
-assignees: ''
 ---
 
 **Describe the bug**

--- a/.github/ISSUE_TEMPLATE/feature_request.md
+++ b/.github/ISSUE_TEMPLATE/feature_request.md
@@ -3,7 +3,6 @@ name: Feature request
 about: Suggest an idea for this project
 title: Request a feature
 labels: enhancement
-assignees: ''
 ---
 
 **Is your feature request related to a problem? Please describe.**

--- a/README.md
+++ b/README.md
@@ -1,3 +1,4 @@
 # cdn.kernvalley.us
 [![GitHub Actions Status](https://github.com/shgysk8zer0/cdn.kernvalley.us/workflows/Node%20CI/badge.svg)](https://github.com/shgysk8zer0/cdn.kernvalley.us/actions)
 [![Build Status](https://travis-ci.com/shgysk8zer0/cdn.kernvalley.us.svg?branch=master)](https://travis-ci.org/shgysk8zer0/cdn.kernvalley.us)
+[![Netlify Status](https://api.netlify.com/api/v1/badges/85d259fa-ea7b-4de4-ae8f-7adf5237b807/deploy-status)](https://app.netlify.com/sites/hardcore-bhaskara-69a703/deploys)


### PR DESCRIPTION
Resolves #103

Also updates issue templates to omit "assignees`

