### PR TITLE
Remove usage of `import.meta.url`

### DIFF
--- a/components/calendar-view.js
+++ b/components/calendar-view.js
@@ -1,3 +1,5 @@
+import { meta } from '../../import.meta.js';
+
 const now = new Date();
 
 customElements.define('calendar-view', class CalendarElement extends HTMLElement {
@@ -13,7 +15,7 @@ customElements.define('calendar-view', class CalendarElement extends HTMLElement
 			this.year = year;
 		}
 
-		fetch(new URL('calendar-view.html', import.meta.url)).then(async resp => {
+		fetch(new URL('./components/calendar-view.html', meta.url)).then(async resp => {
 			const parser = new DOMParser();
 			const html = await resp.text();
 			const doc = parser.parseFromString(html, 'text/html');

--- a/components/leaflet/map.js
+++ b/components/leaflet/map.js
@@ -1,4 +1,5 @@
 import { getLocation } from '../../js/std-js/functions.js';
+import { meta } from '../../import.meta.js';
 import {
 	map as LeafletMap,
 	tileLayer as LeafletTileLayer
@@ -15,7 +16,7 @@ customElements.define('leaflet-map', class HTMLLeafletMapElement extends HTMLEle
 		this._shadow = this.attachShadow({ mode: 'closed' });
 
 		Promise.resolve().then(async () => {
-			const resp = await fetch(new URL('map.html', import.meta.url));
+			const resp = await fetch(new URL('./components/leaflet/map.html', meta.url));
 			const html = await resp.text();
 			const parser = new DOMParser();
 			const doc = parser.parseFromString(html, 'text/html');

--- a/components/login-form/login-form.js
+++ b/components/login-form/login-form.js
@@ -1,11 +1,12 @@
 import User from '/js/User.js';
+import { meta } from '../../import.meta.js';
 import '/components/gravatar-img.js';
 import '/components/toast-message.js';
 import '/components/register-button.js';
 import '/components/login-button.js';
 import '/components/logout-button.js';
 
-const templateHTML = new URL('./login-form.html', import.meta.url);
+const templateHTML = new URL('./components/login-form/login-form.html', meta.url);
 
 export default class HTMLLoginFormElement extends HTMLElement {
 	constructor() {

--- a/components/open-street-map.js
+++ b/components/open-street-map.js
@@ -1,4 +1,5 @@
 // @TODO Only import what is needed from Leaflet
+import { meta } from '../../import.meta.js';
 import * as Leaflet from 'https://unpkg.com/leaflet@1.6.0/dist/leaflet-src.esm.js';
 import HTMLMapMarkerElement from './map-marker.js';
 import HTMLImageOverlayElement from './image-overlay.js';
@@ -18,7 +19,7 @@ export default class HTMLOpenStreetMapElement extends HTMLElement {
 		this._shadow = this.attachShadow({ mode: 'closed' });
 
 		Promise.resolve().then(async () => {
-			const resp = await fetch(new URL('open-street-map.html', import.meta.url));
+			const resp = await fetch(new URL('./components/open-street-map.html', meta.url));
 			const html = await resp.text();
 			const parser = new DOMParser();
 			const doc = parser.parseFromString(html, 'text/html');

--- a/components/payment-form/payment-form.js
+++ b/components/payment-form/payment-form.js
@@ -1,3 +1,5 @@
+import { meta } from '../../import.meta.js';
+
 function uuidv4() {
 	return ([1e7]+-1e3+-4e3+-8e3+-1e11).replace(/[018]/g, c =>
 		(c ^ crypto.getRandomValues(new Uint8Array(1))[0] & 15 >> c / 4).toString(16)
@@ -171,7 +173,7 @@ if ('customElements' in window) {
 		}
 
 		async connectedCallback() {
-			const resp = await fetch(new URL('./payment-form.html', import.meta.url));
+			const resp = await fetch(new URL('./components/payment-form/payment-form.html', meta.url));
 			if (resp.ok) {
 				const parser = new DOMParser();
 				const frag = document.createDocumentFragment();

--- a/components/registration-form/registration-form.js
+++ b/components/registration-form/registration-form.js
@@ -1,3 +1,4 @@
+import { meta } from '../../import.meta.js';
 import User from '/js/User.js';
 import '/components/toast-message.js';
 import '/components/register-button.js';
@@ -5,7 +6,7 @@ import '/components/login-button.js';
 import '/components/logout-button.js';
 import '/components/login-form/login-form.js';
 
-const templateHTML = new URL('./registration-form.html', import.meta.url);
+const templateHTML = new URL('./components/registration-form/registration-form.html', meta.url);
 
 export default class HTMLRegistrationFormElement extends HTMLElement {
 	constructor() {

--- a/components/share-to-button/share-to-button.js
+++ b/components/share-to-button/share-to-button.js
@@ -1,3 +1,5 @@
+import { meta } from '../../import.meta.js';
+
 const urls = {
 	facebook: 'https://www.facebook.com/sharer/sharer.php?u&t',
 	twitter: 'https://twitter.com/intent/tweet/?text&url',
@@ -109,7 +111,7 @@ customElements.define('share-to-button', class HTMLShareToButtonElement extends 
 		this.setAttribute('tabindex', '0');
 		this.attachShadow({mode: 'open'});
 
-		fetch(new URL('./share-to-button.html', import.meta.url)).then(async resp => {
+		fetch(new URL('./share-to-button.html', meta.url)).then(async resp => {
 			const parser = new DOMParser();
 			const html = await resp.text();
 			const doc = parser.parseFromString(html, 'text/html');

--- a/components/slide-show/slide-show.js
+++ b/components/slide-show/slide-show.js
@@ -1,3 +1,5 @@
+import { meta } from '../../import.meta.js';
+
 async function sleep(ms = 1000) {
 	await new Promise(resolve => setTimeout(() => resolve(), ms));
 }
@@ -18,12 +20,12 @@ if ('customElements' in self && !(customElements.get('slide-show') instanceof HT
 			super();
 			this.attachShadow({ mode: 'open' });
 
-			fetch(new URL('./slide-show.html', import.meta.url)).then(async resp => {
+			fetch(new URL('./components/slide-show/slide-show.html', meta.url)).then(async resp => {
 				const html = await resp.text();
 				const parser = new DOMParser();
 				const doc = parser.parseFromString(html, 'text/html');
 				const style = document.createElement('link');
-				style.href = new URL('./slide-show.css', import.meta.url);
+				style.href = new URL('./components/slide-show/slide-show.css', meta.url);
 				style.rel = 'stylesheet';
 
 				this.shadowRoot.append(style, ...doc.head.children, ...doc.body.children);

--- a/components/toast-message.js
+++ b/components/toast-message.js
@@ -1,10 +1,11 @@
+import { meta } from '../import.meta.js';
 customElements.define('toast-message', class HTMLToastMessageElement extends HTMLElement {
 	constructor(message = null) {
 		super();
 		this.hidden = ! this.open;
 		this.attachShadow({mode: 'open'});
 
-		fetch(new URL('toast-message.html', import.meta.url)).then(async resp => {
+		fetch(new URL('./components/toast-message.html', meta.url)).then(async resp => {
 			const parser = new DOMParser();
 			const html = await resp.text();
 			const doc = parser.parseFromString(html, 'text/html');

--- a/components/weather-current.js
+++ b/components/weather-current.js
@@ -1,3 +1,4 @@
+import { meta } from '../../import.meta.js';
 import {shadows, clearSlot, getWeatherByPostalCode, createIcon, getIcon, getSprite} from './weather-helper.js';
 
 customElements.define('weather-current', class HTMLWeatherForecastElement extends HTMLElement {
@@ -10,7 +11,7 @@ customElements.define('weather-current', class HTMLWeatherForecastElement extend
 		}
 
 		Promise.resolve(this.attachShadow({mode: 'closed'})).then(async shadow => {
-			const resp = await fetch(new URL('weather-current.html', import.meta.url));
+			const resp = await fetch(new URL('weather-current.html', meta.url));
 			const html = await resp.text();
 			const parser = new DOMParser();
 			const doc = parser.parseFromString(html, 'text/html');

--- a/components/weather-forecast.js
+++ b/components/weather-forecast.js
@@ -1,3 +1,4 @@
+import { meta } from '../../import.meta.js';
 import {shadows, clearSlot, clearSlots, getForecastByPostalCode, createIcon, getSprite} from './weather-helper.js';
 
 customElements.define('weather-forecast', class HTMLWeatherForecastElement extends HTMLElement {
@@ -10,7 +11,7 @@ customElements.define('weather-forecast', class HTMLWeatherForecastElement exten
 		}
 
 		Promise.resolve(this.attachShadow({mode: 'closed'})).then(async shadow => {
-			const resp = await fetch(new URL('weather-forecast.html', import.meta.url));
+			const resp = await fetch(new URL('weather-forecast.html', meta.url));
 			const html = await resp.text();
 			const parser = new DOMParser();
 			const doc = parser.parseFromString(html, 'text/html');

--- a/import.meta.js
+++ b/import.meta.js
@@ -1,10 +1,5 @@
-export const base = new URL('../', import.meta.url);
+const url = import.meta.url.endsWith('.min.js')
+	? new URL('https://cdn.kernvalley.us').href
+	: new URL(import.meta.url).href;
 
-export const {
-	origin,
-	host,
-	hostname,
-	port,
-	protocol,
-	href,
-} = base;
+export const meta = { url };


### PR DESCRIPTION
Except in a single script, which exports data in a constant.

This should handle issue where Rollup bundles the scripts by using CDN URL instead of URL of exported script.

Also updates all usage to be relative to base URI of CDN/host.