### PR TITLE
Fix template path for `<share-to-button>`

### DIFF
--- a/components/github/user.html
+++ b/components/github/user.html
@@ -5,6 +5,7 @@
 			:host {
 				display: inline-block;
 				font-family: 'Roboto', sans-serif;
+				text-align: left;
 				padding: 0.7em 0.8em;
 				margin: 0.5em;
 				border: 1px solid #cecece;

--- a/components/share-to-button/share-to-button.js
+++ b/components/share-to-button/share-to-button.js
@@ -111,7 +111,7 @@ customElements.define('share-to-button', class HTMLShareToButtonElement extends 
 		this.setAttribute('tabindex', '0');
 		this.attachShadow({mode: 'open'});
 
-		fetch(new URL('./share-to-button.html', meta.url)).then(async resp => {
+		fetch(new URL('./components/share-to-button/share-to-button.html', meta.url)).then(async resp => {
 			const parser = new DOMParser();
 			const html = await resp.text();
 			const doc = parser.parseFromString(html, 'text/html');


### PR DESCRIPTION
Use path relative to base rather than current directory.

Resolves #21