### PR TITLE
Add Router & HTMLCustomElement base class

### DIFF
--- a/components/custom-element.js
+++ b/components/custom-element.js
@@ -1,0 +1,148 @@
+import { meta } from '../import.meta.js';
+
+function setAttrs(el = null, {
+	attrs     = {},
+	data      = {},
+	css       = {},
+	classList = [],
+	slot      = null,
+	text      = null,
+} = {}) {
+	if (typeof el === 'string') {
+		el = document.createElement(el);
+	}
+
+	Object.entries(attrs).forEach(([key, val]) => {
+		switch(typeof val) {
+		case 'string':
+			el.setAttribute(key, val);
+			break;
+
+		case 'boolean':
+			el.toggleAttribute(key, val);
+			break;
+
+		default:
+			el.setAttribute(key, '');
+		}
+	});
+
+	Object.entries(data).forEach(([key, val]) => el.dataset[key] = val);
+	Object.entries(css).forEach(([key, val]) => el.style.setProperty(key, val));
+
+	if (classList.length !== 0) {
+		el.classList.add(...classList);
+	}
+
+	if (typeof text === 'string') {
+		el.textContent = text;
+	}
+
+	if (typeof slot === 'string') {
+		el.slot = slot;
+	}
+
+	return el;
+}
+
+export default class HTMLCustomElement extends HTMLElement {
+	get ready() {
+		return new Promise(resolve => {
+			if (this.shadowRoot !== null && this.shadowRoot.childElementCount === 0) {
+				this.addEventListener('ready', () => resolve(this), {once: true});
+			} else {
+				resolve(this);
+			}
+		}).then(() => this);
+	}
+
+	get stylesLoaded() {
+		return this.ready.then(async () => {
+			if (this.shadowRoot !== null) {
+				const stylesheets = this.shadowRoot.querySelectorAll('link[rel="stylesheet"][href]');
+				await Promise.all([...stylesheets].map(async link => {
+					if (! link.disabled && link.sheet === null) {
+						await new Promise((res, rej) => {
+							link.addEventListener('load', () => res(), {once: true});
+							link.addEventListener('error', () => rej(`Error loading ${link.href}`), {once: true});
+						});
+					}
+					// @TODO Wait for `@import` loading
+					// link.sheet.rules.filter(rule => rule.type === CSSRule.IMPORT_RULE)
+				}));
+			}
+			return this;
+		});
+	}
+
+	async getSlot(slot) {
+		await this.ready;
+		return this.shadowRoot.querySelector(`slot[name="${CSS.escape(slot)}"]`);
+	}
+
+	async getSlotted(slot) {
+		const el = await this.getSlot(slot);
+
+		if (el instanceof HTMLElement) {
+			return el.assignedNodes();
+		} else {
+			return [];
+		}
+	}
+
+	async clearSlot(slot) {
+		const slotted = await this.getSlotted(slot);
+		slotted.forEach(el => el.remove());
+	}
+
+	async setSlot(slot, content, {
+		replace   = true,
+		tag       = 'span',
+		attrs     = {},
+		data      = {},
+		css       = {},
+		classList = [],
+	} = {}) {
+		if (replace) {
+			await this.clearSlot(slot);
+		}
+
+		if (typeof content === 'string') {
+			const el = document.createElement(tag);
+			el.textContent = content;
+			return this.setSlot(slot, el, {
+				replace,
+				attrs,
+				data,
+				css,
+				classList,
+				slot,
+			});
+		} else if (content instanceof HTMLElement) {
+			this.append(setAttrs(content, {attrs, data, css, classList, slot}));
+		} else if (Array.isArray(content)) {
+			return content.map(item => this.setSlot(slot, item, {
+				replace: false,
+				tag,
+				attrs,
+				classList,
+				data,
+				css,
+			}));
+		}
+	}
+
+	async getTemplate(url, {
+		cache   = 'default',
+		mode    = 'cors',
+		headers = new Headers({
+			Accept: 'text/html',
+		})
+	} = {}) {
+		const resp = await fetch(new URL(url, meta.url), { cache, mode, headers });
+		const doc = new DOMParser().parseFromString(await resp.text(), 'text/html');
+		const frag = document.createDocumentFragment();
+		frag.append(...doc.head.children, ...doc.body.children);
+		return frag;
+	}
+}

--- a/components/github/user.js
+++ b/components/github/user.js
@@ -1,6 +1,6 @@
 import { $ } from '../../js/std-js/functions.js';
-import { meta } from '../../import.meta.js';
 const ENDPOINT = 'https://api.github.com';
+import CustomElement from '../custom-element.js';
 
 async function getUser(user) {
 	const key = `github-user-${user}`;
@@ -32,30 +32,19 @@ async function getUser(user) {
 
 }
 
-customElements.define('github-user', class HTMLGitHubUserElement extends HTMLElement {
+customElements.define('github-user', class HTMLGitHubUserElement extends CustomElement {
 	constructor(user = null) {
 		super();
 		this.hidden = true;
 		this.attachShadow({mode: 'open'});
+
 		if (typeof user === 'string') {
 			this.user = user;
 		}
 
-		fetch(new URL('./components/github/user.html', meta.url)).then(async resp => {
-			const parser = new DOMParser();
-			const doc = parser.parseFromString(await resp.text(), 'text/html');
-			this.shadowRoot.append(...doc.head.children, ...doc.body.children);
+		this.getTemplate('./components/github/user.html').then(tmp => {
+			this.shadowRoot.append(tmp);
 			this.dispatchEvent(new Event('ready'));
-		});
-	}
-
-	get ready() {
-		return new Promise(resolve => {
-			if (this.shadowRoot.childElementCount === 0) {
-				this.addEventListener('ready', () => resolve(this), {once: true});
-			} else {
-				resolve(this);
-			}
 		});
 	}
 

--- a/components/schema-element.js
+++ b/components/schema-element.js
@@ -1,0 +1,27 @@
+import HTMLCustomElement from './custom-element.js';
+
+export default class HTMLSchemaElement extends HTMLCustomElement {
+	get itemprop() {
+		return this.getAttribute('itemprop');
+	}
+
+	set itemprop(val) {
+		this.setAttribute('itemprop', val);
+	}
+
+	get itemscope() {
+		return this.hasAttribute('itemscope');
+	}
+
+	set itemscope(val) {
+		this.toggleAttribute('itemscope', val);
+	}
+
+	get itemtype() {
+		return this.getAttribute('itemtype');
+	}
+
+	set itemtype(val) {
+		this.setAttribute('itemtype', val);
+	}
+}

--- a/components/share-to-button/share-to-button.js
+++ b/components/share-to-button/share-to-button.js
@@ -1,4 +1,4 @@
-import { meta } from '../../import.meta.js';
+import CustomElement from '../custom-element.js';
 
 const urls = {
 	facebook: 'https://www.facebook.com/sharer/sharer.php?u&t',
@@ -105,27 +105,23 @@ async function share({
 	}
 }
 
-customElements.define('share-to-button', class HTMLShareToButtonElement extends HTMLElement {
+customElements.define('share-to-button', class HTMLShareToButtonElement extends CustomElement {
 	constructor() {
 		super();
 		this.setAttribute('tabindex', '0');
 		this.attachShadow({mode: 'open'});
 
-		fetch(new URL('./components/share-to-button/share-to-button.html', meta.url)).then(async resp => {
-			const parser = new DOMParser();
-			const html = await resp.text();
-			const doc = parser.parseFromString(html, 'text/html');
-			this.shadowRoot.append(...doc.head.children, ...doc.body.children);
-
-			this.addEventListener('click', () => share({
-				target: this.target,
-				title: this.shareTitle,
-				text: this.text,
-				url: this.url,
-			}));
-
+		this.getTemplate('./components/share-to-button/share-to-button.html').then(tmp => {
+			this.shadowRoot.append(tmp);
 			this.dispatchEvent(new Event('ready'));
 		});
+
+		this.addEventListener('click', () => share({
+			target: this.target,
+			title: this.shareTitle,
+			text: this.text,
+			url: this.url,
+		}));
 
 
 	}

--- a/components/slide-show/slide-show.js
+++ b/components/slide-show/slide-show.js
@@ -1,3 +1,4 @@
+import CustomElement from '../custom-element.js';
 import { meta } from '../../import.meta.js';
 
 async function sleep(ms = 1000) {
@@ -15,20 +16,16 @@ async function visible() {
 }
 
 if ('customElements' in self && !(customElements.get('slide-show') instanceof HTMLElement)) {
-	customElements.define('slide-show', class HTMLSlideShowElement extends HTMLElement {
+	customElements.define('slide-show', class HTMLSlideShowElement extends CustomElement {
 		constructor() {
 			super();
 			this.attachShadow({ mode: 'open' });
 
-			fetch(new URL('./components/slide-show/slide-show.html', meta.url)).then(async resp => {
-				const html = await resp.text();
-				const parser = new DOMParser();
-				const doc = parser.parseFromString(html, 'text/html');
+			this.getTemplate('./components/slide-show/slide-show.html').then(async tmp => {
 				const style = document.createElement('link');
 				style.href = new URL('./components/slide-show/slide-show.css', meta.url);
 				style.rel = 'stylesheet';
-
-				this.shadowRoot.append(style, ...doc.head.children, ...doc.body.children);
+				tmp.append(style);
 
 				const actionHandler = async action => {
 					switch (action) {
@@ -59,7 +56,7 @@ if ('customElements' in self && !(customElements.get('slide-show') instanceof HT
 					}
 				};
 
-				this.shadowRoot.querySelectorAll('[data-action]').forEach(btn => {
+				tmp.querySelectorAll('[data-action]').forEach(btn => {
 					btn.addEventListener('click', ({ target }) => {
 						if (this.contains(target)) {
 							const action = target.closest('[slot]').assignedSlot.closest('[data-action]').dataset.action;
@@ -72,6 +69,8 @@ if ('customElements' in self && !(customElements.get('slide-show') instanceof HT
 						passive: true,
 					});
 				});
+
+				this.shadowRoot.append(tmp);
 
 				const currentSlot = this.shadowRoot.querySelector('slot[name="displayed"]');
 


### PR DESCRIPTION
- Basic router handling hash changes
- Custom Elements base class with `getTemplate`, `read` methods, etc.
- Rewrite `<github-user>` & `<slide-show>` components to extend that base class
- SchemaElement class extending that base class with getters/setters for structured data
