### PR TITLE
Delegate PWA install prompt event to <pwa-prompt>

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- markdownlint-disable -->
 ## [Unreleased]
 
+### Fixed
+- Delegate `beforeinstallprompt` event handling to `<pwa-prompt>` and `event.prompt()` on install button click
+
 ### Changed
 - Add support for `<template>`s for `<leaflet-marker>` popups
 

--- a/components/pwa/install.js
+++ b/components/pwa/install.js
@@ -46,15 +46,13 @@ registerCustomElement('pwa-install', class HTMLPWAInstallButton extends HTMLButt
 				const PWAPrompt = customElements.get('pwa-prompt');
 
 				if (manifest) {
-					const el = new PWAPrompt(manifest);
+					const el = new PWAPrompt(manifest, event);
 					document.body.append(el);
 					const { install } = await el.prompt();
 
 					el.remove();
-
 					if (install === true) {
-						const { outcome } = await event.prompt();
-						const detail = {outcome, playforms: event.platforms};
+						const detail = {install, playforms: event.platforms};
 						this.dispatchEvent(new CustomEvent('install', {detail}));
 						this.hidden = true;
 						setTimeout(() => this.remove(), 500);

--- a/components/pwa/prompt.js
+++ b/components/pwa/prompt.js
@@ -86,7 +86,7 @@ HTMLCustomElement.register('pwa-prompt', class HTMLPWAPromptElement extends HTML
 		screenshots          = null,
 		features             = null,
 		related_applications = [],
-	} = {}) {
+	} = {}, event) {
 		super();
 		this.attachShadow({mode: 'open'});
 
@@ -98,7 +98,15 @@ HTMLCustomElement.register('pwa-prompt', class HTMLPWAPromptElement extends HTML
 						break;
 
 					case 'install':
-						el.addEventListener('click', () => this.close({install: true}));
+						if (event instanceof Event && event.prompt instanceof Function) {
+							el.addEventListener('click', async () => {
+								await event.prompt();
+								this.close({install: true});
+							});
+						} else {
+							console.info({event});
+							el.addEventListener('click', () => this.close({install: false}));
+						}
 						break;
 				}
 			});


### PR DESCRIPTION
Chrome has gotten stricter on installing PWAs if the `beforeinstallprompt` event is not directly handled by a user gester. To remedy this, pass the event into `<pwa-prompt>` and call `event.prompt()` on install botton click.