### PR TITLE
Add toolbar slot to Leaflet Maps

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- markdownlint-disable -->
 ## [Unreleased]
 
+### Added
+- `<slot name="toolbar">` to `<leaflet-map>`
+
 ## [v1.0.7] - 2020-07-20
 
 ### Fixed

--- a/components/leaflet/map.css
+++ b/components/leaflet/map.css
@@ -5,7 +5,37 @@
 	contain: strict;
 }
 
-:host(:fullscreen) ::slotted([slot="map"]), :host(:fullscreen) #map-fallback {
+[part~="container"] {
+	position: relative;
+	height: var(--map-height, 400px);
+	width: var(--map-width, 600px);
+	contain: strict;
+}
+
+::slotted([slot="toolbar"]) {
+	display: flex;
+	flex-direction: row;
+	flex-wrap: nowrap;
+	gap: 0.4em;
+	overflow-x: auto;
+	overflow-y: hidden;
+	width: 100%;
+	height: var(--map-toolbar-height, 4rem);
+	position: fixed;
+	z-index: 401;
+	top: 0;
+	left: 0;
+	right: 0;
+	opacity: 0.2;
+	transition: opacity 400ms ease-in-out;
+}
+
+::slotted([slot="toolbar"]:hover) {
+	opacity: 1;
+}
+
+:host(:fullscreen) [part~="container"], :host(:fullscreen) ::slotted([slot="map"]),
+:host(:fullscreen) #map-fallback {
 	width: 100%;
 	height: 100%;
 }

--- a/components/leaflet/map.html
+++ b/components/leaflet/map.html
@@ -2,19 +2,22 @@
 <html lang="en" dir="ltr">
 	<head>
 		<meta charset="utf-8" />
-		<link rel="stylesheet" href="https://unpkg.com/leaflet@1.6.0/dist/leaflet.css" integrity="sha512-xwE/Az9zrjBIphAcBb3F6JVqxf46+CDLwfLMHloNu6KEQCAWi6HcDUbeOfBIptF7tcCzusKFjFw2yuvEpDL9wQ==" crossorigin=""/>
+		<link rel="stylesheet" href="https://unpkg.com/leaflet@1.6.0/dist/leaflet.css" integrity="sha512-xwE/Az9zrjBIphAcBb3F6JVqxf46+CDLwfLMHloNu6KEQCAWi6HcDUbeOfBIptF7tcCzusKFjFw2yuvEpDL9wQ==" crossorigin="" />
 		<link rel="stylesheet" href="./map.css" media="all" crossorigin="" />
 	</head>
 	<body>
-		<slot name="map">
-			<!-- Be sure to load Leaflet CSS if assigning this slot -->
-			<div id="map-fallback" part="map"></div>
-		</slot>
-		<slot name="attribution">
-			<a part="attribution" href="https://wikimediafoundation.org/wiki/Maps_Terms_of_Use">Wikimedia</a>
-		</slot>
-		<slot name="markers"></slot>
-		<slot name="overlays"></slot>
-		<slot name="geojson"></slot>
+		<div part="container">
+			<slot name="toolbar"></slot>
+			<slot name="map">
+				<!-- Be sure to load Leaflet CSS if assigning this slot -->
+				<div id="map-fallback" part="map"></div>
+			</slot>
+			<slot name="attribution">
+				<a part="attribution" href="https://wikimediafoundation.org/wiki/Maps_Terms_of_Use">Wikimedia</a>
+			</slot>
+			<slot name="markers"></slot>
+			<slot name="overlays"></slot>
+			<slot name="geojson"></slot>
+		</div>
 	</body>
 </html>

--- a/components/leaflet/map.js
+++ b/components/leaflet/map.js
@@ -50,6 +50,17 @@ HTMLCustomElement.register('leaflet-map', class HTMLLeafletMapElement extends HT
 				});
 			});
 
+			doc.querySelectorAll('slot[name]').forEach(slot => {
+				slot.addEventListener('slotchange', ({target}) => {
+					this.dispatchEvent(new CustomEvent('change', {
+						detail: {
+							slot: target.name,
+							nodes: target.assignedElements(),
+						}
+					}));
+				});
+			});
+
 			this._shadow.append(...doc.head.children, ...doc.body.children);
 			await Promise.all(stylesheets);
 			this.dispatchEvent(new Event('populated'));


### PR DESCRIPTION
Since buttons & search are common needs, provide a `<slot>` for toolbars. No JS handlers, and might conflict with `zoomcontrol`
