### PR TITLE
Add missing JS controls for leaflet map toolbar attribute

### DIFF
--- a/components/leaflet/map.css
+++ b/components/leaflet/map.css
@@ -27,7 +27,7 @@
 	transition: opacity 400ms ease-in-out;
 }
 
-::slotted([slot="toolbar"]:hover) {
+:host([toolbar]) ::slotted([slot="toolbar"]:hover) {
 	opacity: 1;
 }
 

--- a/components/leaflet/map.js
+++ b/components/leaflet/map.js
@@ -264,6 +264,14 @@ HTMLCustomElement.register('leaflet-map', class HTMLLeafletMapElement extends HT
 		return this.getAttribute('tilesrc') || HTMLLeafletMapElement.wikimedia;
 	}
 
+	get toolbar() {
+		return this.hasAttribute('toolbar');
+	}
+
+	set toolbar(val) {
+		this.toggleAttribute('toolbar', val);
+	}
+
 	get attribution() {
 		const slot = this._shadow.querySelector('slot[name="attribution"]');
 		const nodes = slot.assignedNodes();


### PR DESCRIPTION
It's a boolean attrtibute, so use `hasAttribute` & `toggleAttribute`.