### PR TITLE
Fix HTMLToastMessageElement.show()

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,10 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- markdownlint-disable -->
 ## [Unreleased]
 
+## [v1.0.10] - 2020-08-28
+
 ### Added
+- `<button is="print-button">` custom element
 - `<permissions-switch>` element for handling permission changes and requests
 - `<button is="register-protocol-handler">` component
 - `<html-notification>`, a custom element modelled after the `Notification` API
@@ -17,6 +20,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Changed
 - Add support for `HTMLNotificationElement.vibrate` and `HTMLNotificationElement.silent`
 - Set default referrer policies on imported templates and stylesheets
+
+### Fixed
+- Fix share button show method [#239](https://github.com/shgysk8zer0/cdn.kernvalley.us/issues/239)
 
 ## [v1.0.9] - 2020-07-28
 

--- a/components/print-button.js
+++ b/components/print-button.js
@@ -1,0 +1,16 @@
+import { registerCustomElement } from '../js/std-js/functions.js';
+
+function print() {
+	window.print();
+}
+
+registerCustomElement('print-button', class HTMLPrintButtonElement extends HTMLButtonElement {
+	connectedCallback() {
+		if (window.print instanceof Function) {
+			this.addEventListener('click', print, { capture: true });
+		} else {
+			alert('Not supported');
+			this.remove();
+		}
+	}
+}, { extends: 'button' });

--- a/components/share-button.js
+++ b/components/share-button.js
@@ -1,5 +1,5 @@
-import webShareApi from '/js/std-js/webShareApi.js';
-import { loaded } from '/js/std-js/functions.js';
+import webShareApi from '../js/std-js/webShareApi.js';
+import { loaded } from '../js/std-js/functions.js';
 import {
 	facebook,
 	twitter,
@@ -9,7 +9,7 @@ import {
 	gmail,
 	email,
 	clipboard,
-} from '/js/std-js/share-config.js';
+} from '../js/std-js/share-config.js';
 
 import { registerCustomElement } from '../js/std-js/functions.js';
 

--- a/components/toast-message.css
+++ b/components/toast-message.css
@@ -37,7 +37,7 @@
 	right: 0;
 	bottom: 0;
 	left: 0;
-	transition: background 300 ease-in-out;
+	transition: background 300ms ease-in-out;
 }
 
 .backdrop[hidden] {

--- a/components/toast-message.js
+++ b/components/toast-message.js
@@ -109,6 +109,7 @@ HTMLCustomElement.register('toast-message', class HTMLToastMessageElement extend
 	}
 
 	async show() {
+		await this.whenConnected;
 		await this.ready;
 		this.hidden = false;
 		const timer = this.timer;


### PR DESCRIPTION
Wait for element to be connected (added to DOM) before attempting to `show()`. Resolves #239 

Also adds `<button is="print-button">`