### PR TITLE
Add positioning & fit options for `<ad-block>` images

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,9 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- markdownlint-disable -->
 ## [Unreleased]
 
+### Added
+- Postioning and fit settings for `<ad-block>` images
+
 ### Changed
 - Update Leaflet to [v1.7.1](https://leafletjs.com/2020/09/04/leaflet-1.7.1.html)
 - Make more use of `crossorigin="anonymous"` and `referrerpolicy="no-referrer"`

--- a/components/ad/block.css
+++ b/components/ad/block.css
@@ -99,3 +99,55 @@
 	max-width: 100%;
 	max-height: 100%;
 }
+
+::slotted([slot="image"][data-fit="fill"]) {
+	object-fit: fill;
+}
+
+::slotted([slot="image"][data-fit="cover"]) {
+	object-fit: cover;
+}
+
+::slotted([slot="image"][data-fit="contain"]) {
+	object-fit: contain;
+}
+
+::slotted([slot="image"][data-fit="scale-down"]) {
+	object-fit: scale-down;
+}
+
+::slotted([slot="image"][data-position="top"]) {
+	object-position: center top;
+}
+
+::slotted([slot="image"][data-position="bottom"]) {
+	object-position: center bottom;
+}
+
+::slotted([slot="image"][data-position="right"]) {
+	object-position: right center;
+}
+
+::slotted([slot="image"][data-position="left"]) {
+	object-position: left center;
+}
+
+::slotted([slot="image"][data-position="top-left"]) {
+	object-position: left top;
+}
+
+::slotted([slot="image"][data-position="bottom-left"]) {
+	object-position: left bottom;
+}
+
+::slotted([slot="image"][data-position="top-right"]) {
+	object-position: right top;
+}
+
+::slotted([slot="image"][data-position="bottom-right"]) {
+	object-position: bottom top;
+}
+
+::slotted([slot="image"][data-position="top-right"]) {
+	object-position: right top;
+}


### PR DESCRIPTION
Adds CSS for `::slotted([data-*])` to apply the correct `object-fit` & `object-position` rules.