### PR TITLE
Report PWA installs to Google Analytics

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ## [Unreleased]
 
 ### Added
+- Add install event resporting to `window.ga()` if available
 - `<ad-block>` can now navigate to internal URLs instead of opening new tab
 - `<ad-block url="...">` now handles UTM params
 

--- a/components/pwa/prompt.js
+++ b/components/pwa/prompt.js
@@ -226,6 +226,19 @@ HTMLCustomElement.register('pwa-prompt', class HTMLPWAPromptElement extends HTML
 
 	close(detail = null) {
 		this.open = false;
+
+		if (typeof detail === 'boolean' && window.ga instanceof Function) {
+			/**
+			 * Probably safe to assume `ga` is the function for Google Analytics,
+			 * so send a pwa-install event
+			 */
+			window.ga('send', {
+				hitType: 'event',
+				eventCategory: 'pwa-install',
+				eventLabel: 'Installed PWA',
+				transport: 'beacon',
+			});
+		}
 		this.dispatchEvent(new CustomEvent('close', { detail }));
 	}
 


### PR DESCRIPTION
- Add install event reporting to `window.ga()` if available
