### PR TITLE
Add and use new method to get slotted items by index

### DIFF
--- a/components/ad/block.js
+++ b/components/ad/block.js
@@ -260,8 +260,30 @@ HTMLCustomElement.register('ad-block', class HTMLAdBlockElement extends HTMLCust
 		}
 	}
 
+	async getJSON() {
+		const { label, description, image, callToAction, id, title, url, source, medium, campaign, term, content, layout, theme, imageFit, imagePosition } = this;
+		return JSON.stringify({
+			id,
+			title,
+			label: await label,
+			description: await description,
+			image: await image,
+			callToAction: await callToAction,
+			layout,
+			theme,
+			url,
+			source,
+			medium,
+			campaign,
+			term,
+			content,
+			imageFit,
+			imagePosition,
+		});
+	}
+
 	get callToAction() {
-		return this.getSlot('calltoaction').then(el => {
+		return this.getSlottedItem('calltoaction').then(el => {
 			if (el instanceof HTMLElement) {
 				return el.textContent;
 			} else {
@@ -299,7 +321,7 @@ HTMLCustomElement.register('ad-block', class HTMLAdBlockElement extends HTMLCust
 	}
 
 	get description() {
-		return this.getSlot('description').then(el => {
+		return this.getSlottedItem('description').then(el => {
 			if (el instanceof HTMLElement) {
 				return el.textContent;
 			} else {
@@ -327,7 +349,13 @@ HTMLCustomElement.register('ad-block', class HTMLAdBlockElement extends HTMLCust
 	}
 
 	get image() {
-		return this.getSlot('image');
+		return this.getSlottedItem('image').then(img => {
+			if (img instanceof HTMLImageElement && img.hasAttribute('src')) {
+				return img.src;
+			} else {
+				return null
+			}
+		});
 	}
 
 	set image(val) {
@@ -372,7 +400,7 @@ HTMLCustomElement.register('ad-block', class HTMLAdBlockElement extends HTMLCust
 	}
 
 	get label() {
-		return this.getSlot('label').then(el => {
+		return this.getSlottedItem('label').then(el => {
 			if (el instanceof HTMLElement) {
 				return el.textContent;
 			} else {

--- a/components/ad/block.js
+++ b/components/ad/block.js
@@ -353,7 +353,7 @@ HTMLCustomElement.register('ad-block', class HTMLAdBlockElement extends HTMLCust
 			if (img instanceof HTMLImageElement && img.hasAttribute('src')) {
 				return img.src;
 			} else {
-				return null
+				return null;
 			}
 		});
 	}

--- a/components/custom-element.js
+++ b/components/custom-element.js
@@ -63,6 +63,11 @@ export default class HTMLCustomElement extends HTMLElement {
 		}
 	}
 
+	async getSlottedItem(slot, item = 0) {
+		const slotted = await this.getSlotted(slot);
+		return slotted[item] ?? null;
+	}
+
 	async clearSlot(slot) {
 		const slotted = await this.getSlotted(slot);
 		slotted.forEach(el => el.remove());

--- a/components/custom-element.js
+++ b/components/custom-element.js
@@ -54,7 +54,7 @@ export default class HTMLCustomElement extends HTMLElement {
 	}
 
 	async getSlotted(slot) {
-		const el = await this.getSlot(slot);
+		const el = this.getSlot(slot);
 
 		if (el instanceof HTMLElement) {
 			return el.assignedElements();
@@ -65,7 +65,7 @@ export default class HTMLCustomElement extends HTMLElement {
 
 	async getSlottedItem(slot, item = 0) {
 		const slotted = await this.getSlotted(slot);
-		return slotted[item] ?? null;
+		return slotted.length > item ? slotted[item] : null;
 	}
 
 	async clearSlot(slot) {


### PR DESCRIPTION
Updates `<ad-block>` getters to use this to return slotted content, along with a single method to obtain JSON representation of ad