### PR TITLE
`await` getting slots

### DIFF
--- a/components/custom-element.js
+++ b/components/custom-element.js
@@ -54,7 +54,7 @@ export default class HTMLCustomElement extends HTMLElement {
 	}
 
 	async getSlotted(slot) {
-		const el = this.getSlot(slot);
+		const el = await this.getSlot(slot);
 
 		if (el instanceof HTMLElement) {
 			return el.assignedElements();


### PR DESCRIPTION
Without the `await` keyword, this will never return an `HTMLElement`, which causes all sorts of issues.
