### PR TITLE
Handle zoom & pan in `<leaflet-map>` and `<leaflet-marker>`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 ### Added
 - `<share-button>` now supports an optional `file`
 - Provide minified (Rollup) version of certain custom elements
+- `<leaflet-map>` now dispatches `"zoom"` and `"pan"` events
+- New `WeakMap` for storing zoom handlers
+- Add `minZoom` & `maxZoom` to marker comstructor
+- On `minzoom` or `maxzoom` change, toggle map zoom listener
+
+### Changed
+- Use `WeakMap` for storing maps from elements to markers
 
 ## [v1.0.13] - 2020-12-17
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,8 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 <!-- markdownlint-disable -->
 ## [Unreleased]
 
+## [v1.0.14] - 2021-01-05
+
 ### Added
 - `<share-button>` now supports an optional `file`
 - Provide minified (Rollup) version of certain custom elements

--- a/components/leaflet/map.js
+++ b/components/leaflet/map.js
@@ -8,7 +8,7 @@ import {
 let map = new Map();
 
 /**
- * @see https://leafletjs.com/reference-1.6.0.html#map-factory
+ * @see https://leafletjs.com/reference-1.7.1.html#map-factory
  */
 HTMLCustomElement.register('leaflet-map', class HTMLLeafletMapElement extends HTMLCustomElement {
 	constructor({
@@ -160,6 +160,24 @@ HTMLCustomElement.register('leaflet-map', class HTMLLeafletMapElement extends HT
 		await Promise.all([ this._populated, prom ]);
 		const m = LeafletMap(this.mapElement, {
 			zoomControl: this.zoomControl,
+		});
+
+		const handler = ({ type, target }) => {
+			const event = type === 'move' ? 'pan': 'zoom';
+			const { lat: latitude, lng: longitude } = target.getCenter();
+			const { _northEast: ne, _southWest: sw } = target.getBounds();
+			const bounds = [
+				{ latitude: ne.lat, longitude: ne.lng },
+				{ latitude: sw.lat, longitude: sw.lng },
+			];
+			const zoom = target.getZoom();
+			const detail = { center: { latitude, longitude }, zoom, bounds };
+			this.dispatchEvent(new CustomEvent(event, { detail }));
+		};
+
+		m.on({
+			move: handler,
+			zoom: handler,
 		});
 
 		const { latitude, longitude } = this.center;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "cdn.kernvalley.us",
-  "version": "1.0.1",
+  "version": "1.0.14",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "cdn.kernvalley.us",
-  "version": "1.0.1",
+  "version": "1.0.14",
   "private": true,
   "description": "Static assets for modern web development",
   "repository": {


### PR DESCRIPTION
### Added
- New `WeakMap` for storing zoom handlers
- Add `minZoom` & `maxZoom` to marker comstructor
- On `minzoom` or `maxzoom` change, toggle map zoom listener

### Changed
- Use `WeakMap` for storing maps from elements to markers