### PR TITLE
Update `<leaflet-geojson>`

### DIFF
--- a/components/leaflet/geojson.js
+++ b/components/leaflet/geojson.js
@@ -29,7 +29,9 @@ registerCustomElement('leaflet-geojson', class HTMLLeafletGeoJSONElement extends
 				map.set(this, path);
 
 				if (parent.tagName === 'LEAFLET-MAP' && this.hidden === false) {
-					parent.ready.then(() => path.addTo(parent.map));
+					customElements.whenDefined('leaflet-map').then(() => {
+						parent.ready.then(() => path.addTo(parent.map));
+					});
 				}
 
 				this.dispatchEvent(new Event('ready'));


### PR DESCRIPTION
Rewrite to use `<script slot="data" type="application/geo+json">` instead of only relying on `src` attribute. Using `src` now only `fetch`es the data and creates & appends the `<script>`.

Also adds `HTMLLeafletMapElement.markUserLocation()` method to add a marker indicating the user's location on the map. Requires `<leaflet-marker>` for marker and `<html-notification>` for permission request.