### PR TITLE
New map method for loading markers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -14,6 +14,7 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 - CDN copy of `service-worker.js`, contiaining all service worker handling
 - `HTMLLeafletMarkerElement.getSchemaIcon()` sets icon by schema `@type` using `/img/markers.svg`
 - `HTMLLeafletMarkerElement.getMarkers()` fetches data from `maps.kernvalley.us` and creates markers
+- `HTMLLeafletMapElement.loadMarkers()` appending markers from `HTMLLeafletMarkerElement.getMarkers()`
 
 ### Changed
 - `<pwa-prompt>` now uses images from CDN instead of inline SVG, greatly reducing size

--- a/components/leaflet/map.js
+++ b/components/leaflet/map.js
@@ -557,6 +557,13 @@ HTMLCustomElement.register('leaflet-map', class HTMLLeafletMapElement extends HT
 		return markers;
 	}
 
+	async loadMarkers(...types) {
+		await customElements.whenDefined('leaflet-marker');
+		const Marker = customElements.get('leaflet-marker');
+		const markers = await Marker.getMarkers(...types);
+		this.append(...markers);
+	}
+
 	async attributeChangedCallback(name, oldVal, newVal) {
 		switch (name) {
 			case 'zoom':


### PR DESCRIPTION
`HTMLLeafletMapElement.loadMarkers()` appending markers from `HTMLLeafletMarkerElement.getMarkers()`

```js
customElements.whenDefined("leaflet-map")
	.then(() => customElements.get("leaflet-map"))
	.then(LeafletMap => {
		const map = new LeafletMap();
		map.style.setProperty("--map-width", "100%");
		document.body.append(map);
		map.loadMarkers("towns", "activities", "restaurants", "stores", "landmarks", "civic",
                                             "campgrounds", "cafes", "lodging", "financial", "bars");
		map.coords.then(({ latitude, longitude }) => map.center = { latitude, longitude });
});
```