### PR TITLE
Fix errors introduced in find/replace

### DIFF
--- a/components/leaflet/map.js
+++ b/components/leaflet/map.js
@@ -877,13 +877,13 @@ HTMLCustomElement.register('leaflet-map', class HTMLLeafletMapElement extends HT
 
 			case 'minzoom':
 				if (typeof newVal === 'string') {
-					this.ready.then(() => data.get(this).data.setMinZoom(parseInt(newVal)));
+					this.ready.then(() => data.get(this).map.setMinZoom(parseInt(newVal)));
 				}
 				break;
 
 			case 'maxzoom':
 				if (typeof newVal === 'string') {
-					this.ready.then(() => data.get(this).data.setMaxZoom(parseInt(newVal)));
+					this.ready.then(() => data.get(this).map.setMaxZoom(parseInt(newVal)));
 				}
 				break;
 


### PR DESCRIPTION
Replacing `"map.set"` also replaced `"map.setMinZoom"` and `"map.setMaxZoom"`.

Haven't seen any other such mistakes.