### PR TITLE
Create <install-prompt> element

### DIFF
--- a/components/install/prompt.css
+++ b/components/install/prompt.css
@@ -1,0 +1,336 @@
+:host {
+	display: block;
+	contain: strict;
+	z-index: var(--z-top, 100);
+	background-color: transparent;
+	width: 100vw;
+	height: 100vh;
+	overflow: auto;
+	position: fixed;
+	left: 0;
+	right: 0;
+	top: 0;
+	bottom: 0;
+	box-sizing: border-box;
+	background-color: rgba(0,0,0,0.7);
+	text-align: left;
+}
+
+:host(:not([open])) {
+	display: none;
+}
+
+:host([open]) #container {
+	animation-name: open;
+}
+
+* {
+	box-sizing: border-box;
+}
+
+[part="icon"] > * {
+	width: 100%;
+	height: 100%;
+	object-fit: contain;
+}
+
+#categories {
+	list-style: none;
+	display: flex;
+	flex-direction: row;
+	flex-wrap: no-wrap;
+	overflow-x: auto;
+	gap: 8px;
+}
+
+#categories > [part="category"] {
+	display: inline-block;
+	color: var(--button-primary-color, #fefefe);
+	background-color: var(--button-primary-background);
+	padding: 6px 22px;
+	border-radius: 20px;
+}
+
+button[data-platform="webapp"]:not([hidden]) {
+	background-color: transparent;
+	cursor: pointer;
+	border: none;
+}
+
+[data-click="install"] {
+	transition: opacity 500ms ease-in, filter 500ms ease-in;
+}
+
+[data-click="install"]:disabled {
+	cursor: not-allowed;
+	filter: grayscale(1);
+	opacity: 0.7;
+}
+
+#header {
+	grid-template-areas: "icon title close"
+	"icon details install"
+	"store-banner store-banner store-banner";
+	grid-template-rows: 5vmax minmax(96px, auto) auto;
+	grid-template-columns: 10vmax 1fr auto;
+	grid-column-gap: 2em;
+}
+
+@media (max-width: 600px) {
+	#header {
+		grid-template-areas: "icon title title"
+		"icon . install"
+		"store-banner store-banner store-banner"
+		"details details details";
+		grid-template-rows: 10vmax auto auto auto;
+		grid-template-columns: 10vmax 30px auto;
+		grid-column-gap: 0.4em;
+	}
+
+	#title {
+		text-align: center;
+	}
+
+	#details {
+		padding-top: 16px;
+		padding-bottom: 16px;
+	}
+
+	#close-btn-icon {
+		display: none;
+	}
+}
+
+#icon {
+	grid-area: icon;
+	font-size: 32px;
+	color: #515151;
+}
+
+#install {
+	grid-area: install;
+	text-align: right;
+}
+
+#title {
+	grid-area: title;
+}
+
+#details {
+	grid-area: details;
+	margin: 0;
+}
+
+#close-btn-icon {
+	grid-area: close;
+}
+
+#container {
+	border-radius: 12px;
+	overflow-y: auto;
+	overflow-x: hidden;
+	position: absolute;
+	left: 3vw;
+	right: 3vw;
+	top: 3vh;
+	bottom: 5vh;
+	height: 94vh;
+	width: 94vw;
+	box-sizing: border-box;
+	background-color: #fafafa;
+	padding: 24px;
+	font-family: 'Roboto', sans-serif;
+	color: #212121;
+	animation-duration: 300ms;
+	animation-timing-function: ease-in;
+	margin-bottom: 25px;
+}
+
+[part="description"] {
+	color: #646060;
+}
+
+#details::first-letter, #description::first-letter {
+	margin-left: 1.2em;
+}
+
+#store-banners {
+	grid-area: store-banner;
+}
+
+#platforms-container {
+	display: flex;
+	flex-wrap: wrap;
+	flex-direction: row;
+	justify-content: space-around;
+	margin-top: 12px;
+}
+
+#platforms-container > [data-platform] {
+	margin-bottom: 8px;
+	max-width: 45%;
+}
+
+#platforms-container > [data-platform]:not(:last-of-type) {
+	margin-right: 8px;
+}
+
+@media (prefers-reduced-motion: reduce) {
+	:host([open]) #container {
+		animation-duration: 80ms;
+	}
+}
+
+@media (prefers-color-scheme: dark) {
+	#container {
+		background-color: #232323;
+		color: #fefefe;
+	}
+
+	[part="description"] {
+		color: #bababa;
+	}
+}
+
+[part~="store-badge"] {
+	height: 53px;
+	width: auto;
+}
+
+button:not([hidden]) {
+	display: inline-block;
+	cursor: pointer;
+	background-color: var(--button-primary-background);
+	color: var(--button-primary-color);
+	border: var(--button-primary-border, 1px solid #aaa);
+	border-radius: var(--button-border-radius, initial);
+	box-sizing: border-box;
+}
+
+button:hover {
+	background-color: var(--button-primary-hover-background, var(--button-primary-background));
+	color: var(--button-primary-hover-color, var(--button-primary-color));
+	border: var(--button-primary-hover-border, var(--button-primary-border, 0.2rem inset black));
+}
+
+button:active {
+	background-color: var(--button-primary-active-background, var(--button-primary-background));
+	color: var(--button-primary-active-color, var(--button-primary-color));
+	border: var(--button-primary-active-border, var(--button-primary-border, 0.2rem inset black));
+}
+
+button:focus {
+	outline-width: var(--focus-outline-width, 1px);
+	outline-style: var(--focus-outline-style, dotted);
+	outline-color: var(--focus-outline-color, currentColor);
+}
+
+.btn {
+	padding: 8px 18px;
+}
+
+img {
+	max-width: 100%;
+}
+
+#cancel-btn {
+	border-radius: 18px;
+	min-width: 10%;
+	font-size: 20px;
+	font-weight: bold;
+	background-color: #cd3434;
+	color: #fafafa;
+	float: right;
+	margin-top: 1.5em;
+}
+
+@media (max-width: 600px) {
+	#cancel-btn {
+		margin-left: auto;
+		width: 80vw;
+	}
+}
+
+.no-border, button.no-border {
+	border: none;
+}
+
+.no-background, button.no-background {
+	background: transparent;
+}
+
+.no-margin {
+	margin: 0;
+}
+
+.color-inherit, button.color-inherit {
+	color: inherit;
+}
+
+.grid {
+	display: grid;
+}
+
+@media (min-width: 800px) {
+	#details-container {
+		display: flex;
+		flex-direction: row;
+		justify-content: space-around;
+	}
+
+	[part="screenshots"] {
+		max-width: 45%;
+		object-fit: contain;
+	}
+}
+
+.inline-block:not([hidden]) {
+	display: inline-block;
+}
+
+.flex:not([hidden]) {
+	display: flex;
+}
+
+.flex.row {
+	flex-direction: row;
+}
+
+.flex.space-around {
+	justify-content: space-around;
+}
+
+.float-right {
+	float: right;
+}
+
+.icon, .icon * {
+	color: inherit;
+	max-width: 100%;
+	max-height: 100%;
+	width: auto;
+	height: var(--icon-size, 1em);
+	vertical-align: middle;
+}
+
+.current-color {
+	fill: currentColor;
+}
+
+.clearfix::after {
+	display: block;
+	clear: both;
+	content: "";
+}
+
+@keyframes open {
+	from {
+		opacity: 0.4;
+		transform: scale(0.1);
+	}
+
+	to {
+		opacity: 1;
+		transform: none;
+	}
+}

--- a/components/install/prompt.html
+++ b/components/install/prompt.html
@@ -1,0 +1,102 @@
+<!DOCTYPE html>
+<html>
+	<head>
+		<meta charset="utf-8" />
+		<meta name="color-scheme" content="dark light" />
+	</head>
+	<body>
+		<div id="container">
+			<header id="header" class="grid" part="header">
+				<span id="icon" part="icon">
+					<svg width="192" height="192" viewBox="0 0 12 16">
+						<path fill-rule="evenodd" fill="currentColor" d="M6 5h2v2H6V5zm6-.5V14c0 .55-.45 1-1 1H1c-.55 0-1-.45-1-1V2c0-.55.45-1 1-1h7.5L12 4.5zM11 5L8 2H1v11l3-5 2 4 2-2 3 3V5z"/>
+					</svg>
+				</span>
+				<h2 id="title" class="no-margin">
+					<span part="name">Unknown App</span>
+				</h2>
+				<span id="install">
+					<button type="button" class="btn header-btn install-btn" title="Install as Web A" part="button install-button" data-click="install" disabled="">
+						<slot name="install-icon">
+							<svg class="current-color" height="20" width="20" viewBox="0 0 16 16">
+								<path d="M3 8h10v7.059c0 .492-.472.937-.996.937H4c-.539 0-1-.43-1-1z" overflow="visible"/>
+								<path d="M6.688 2.969a1 1 0 0 0-.657.375L3.22 6.812a1 1 0 0 0-.22.625v1a1 1 0 1 0 2 0v-.656l2.594-3.156a1 1 0 0 0-.907-1.656zm2.218 3a1 1 0 1 0-.031 2l2.156.375V8.5a1 1 0 1 0 2 0v-1a1 1 0 0 0-.812-1l-3-.5a1 1 0 0 0-.313-.031z" overflow="visible"/>
+							</svg>
+						</slot>
+						<span>Install</span>
+					</button>
+				</span>
+				<div id="store-banners" part="banner">
+					<div id="platforms-container">
+						<button data-platform="webapp" part="store-badge pwa-badge" data-click="install" title="Install as Web App" disabled="" hidden="">
+							<slot name="pwa-badge">
+								<img src="https://cdn.kernvalley.us/img/logos/pwa-badge.svg" height="53" width="180" loading="lazy" decoding="async" crossorigin="anonymous" referrerpolicy="no-referrer" alt="Install Web App" />
+							</slot>
+						</button>
+						<a href="https://play.google.com/store/apps/details?id=" data-platform="play" part="store-badge play-badge" class="inline-block" title="Get it on Google Play" target="_blank" rel="norefferer noopener external" hidden="">
+							<slot name="play-badge">
+								<img src="https://cdn.kernvalley.us/img/logos/play-badge.svg" height="53" width="180" loading="lazy" decoding="async" crossorigin="anonymous" referrerpolicy="no-referrer" alt="Google Play Store" />
+							</slot>
+						</a>
+						<a href="https://itunes.apple.com/app/" data-platform="itunes" part="store-badge itunes-badge" class="inline-block" title="Get it on the App Store" target="_blank" rel="norefferer noopener external" hidden="">
+							<slot name="itunes-badge">
+								<img src="https://cdn.kernvalley.us/img/logos/itunes-badge.svg" height="53" width="158" loading="lazy" decoding="async" crossorigin="anonymous" referrerpolicy="no-referrer" alt="App Store" />
+							</slot>
+						</a>
+						<a href="https://www.microsoft.com/store/apps/" data-platform="windows" part="store-badge windows-badge" class="inline-block" title="Get it on the Microsoft Store" target="_blank" rel="norefferer noopener external" hidden="">
+							<slot name="windows-badge">
+								<img src="https://cdn.kernvalley.us/img/logos/windows-badge.svg" height="53" width="147" loading="lazy" decoding="async" crossorigin="anonymous" referrerpolicy="no-referrer" alt="Microsoft Store" />
+							</slot>
+						</a>
+					</div>
+					<hr />
+				</div>
+				<div id="details" part="details">
+					<slot name="details">
+						This app can be installed on your PC or mobile device. This will allow this web app to look and behave like any other installed app. You will find it in your app lists and be able to pin it to your home screen, start menus or task bars. This installed web app will also be able to safely interact with other apps and your operating system.
+					</slot>
+				</div>
+				<button id="close-btn-icon" type="button" class="bo-border no-background color-inherit" title="Close install prompt" part="x-button" data-click="close">
+					<svg class="icon" fill="currentColor" height="20" width="20" viewBox="0 0 12 16">
+						<path fill-rule="evenodd" fill="currentColor" d="M7.48 8l3.75 3.75-1.48 1.48L6 9.48l-3.75 3.75-1.48-1.48L4.52 8 .77 4.25l1.48-1.48L6 6.52l3.75-3.75 1.48 1.48L7.48 8z"/>
+					</svg>
+				</button>
+			</header>
+			<section part="body">
+				<div id="details-container">
+					<div class="features">
+						<h4 id="features-header" class="no-margin" part="features-header">
+							<slot name="features-heading">Key Features</slot>
+						</h4>
+						<ul part="features">
+							<li>When installed, it will be available and display just like a native app</li>
+							<li>Certain content may be available even when on slow networks or offline</li>
+						</ul>
+					</div>
+					<div part="screenshots"></div>
+				</div>
+				<br class="clearfix" />
+				<div part="description-container">
+					<h4 id="description-header" class="no-margin" part="description-header">
+						<slot name="description-heading">Description</slot>
+					</h4>
+					<div id="description" part="description">No description available</div>
+				</div>
+			</section>
+			<section>
+				<h4>Application Categories</h4>
+				<ul id="categories" part="categories"></ul>
+			</section>
+			<footer id="footer" class="clearfix">
+				<button type="button" id="cancel-btn" class="btn footer-btn footer-cancel-btn" title="Close install prompt" part="button cancel-button" data-click="close">
+					<slot name="cancel-icon">
+						<svg class="icon" fill="curerntColor" height="20" width="20" viewBox="0 0 12 16">
+							<path fill-rule="evenodd" fill="currentColor" d="M7.48 8l3.75 3.75-1.48 1.48L6 9.48l-3.75 3.75-1.48-1.48L4.52 8 .77 4.25l1.48-1.48L6 6.52l3.75-3.75 1.48 1.48L7.48 8z"/>
+						</svg>
+					</slot>
+					<span>Cancel</span>
+				</button>
+			</footer>
+		</div>
+	</body>
+</html>

--- a/components/install/prompt.js
+++ b/components/install/prompt.js
@@ -1,0 +1,304 @@
+import { registerCustomElement } from '../../js/std-js/custom-elements.js';
+import { meta } from '../../import.meta.js';
+import { loadStylesheet } from '../../js/std-js/loader.js';
+import { getHTML, getManifest } from '../../js/std-js/http.js';
+import { query, create, text, on, off } from '../../js/std-js/dom.js';
+import { hasGa, send } from '../../js/std-js/google-analytics.js';
+import { confirm } from '../../js/std-js/asyncDialog.js';
+
+function getBySize(opts, width) {
+	if (Array.isArray(opts)) {
+		const match = opts.find(opt => opt.sizes.startsWith(`${width}x`));
+		return match || { src: null };
+	} else {
+		return { src: null };
+	}
+}
+
+function getPicture({
+	opts           = [],
+	sizes          = '100%',
+	decoding       = 'async',
+	loading        = 'lazy',
+	crossOrigin    = 'anonymous',
+	referrerPolicy = 'no-referrer',
+	alt            = 'image',
+	fallbackWidth  = 192,
+} = {}) {
+	const pic = document.createElement('picture');
+	const img = document.createElement('img');
+
+	img.decoding = decoding;
+	img.loading = loading;
+	img.alt = alt;
+	img.sizes = sizes;
+	img.crossOrigin = crossOrigin;
+	img.referrerPolicy = referrerPolicy;
+	img.src = getBySize(opts, fallbackWidth).src;
+
+	const srcs = opts.reduce(((srcs, {src, sizes = '', type = null} = {}) => {
+		const [width = null] = sizes.split('x', 1);
+		if (! (srcs.hasOwnProperty(type))) {
+			srcs[type] = [`${src} ${width}w`];
+		} else {
+			srcs[type].push(`${src} ${width}w`);
+		}
+
+		return srcs;
+	}), {});
+
+	pic.append(...Object.entries(srcs).map(([type, srcs]) => {
+		const src = document.createElement('source');
+		src.type = type;
+		src.srcset = srcs.join(', ');
+		src.sizes = img.sizes;
+		return src;
+	}), img);
+
+	return pic;
+}
+
+function getIcon(...icons) {
+	let icon = icons.find(icon => icon.type === 'image/svg+xml');
+
+	if (icon) {
+		const img = document.createElement('img');
+		img.src = icon.src;
+		img.decoding = 'async';
+		img.loading = 'lazy';
+		img.alt = 'App Icon';
+		img.height = 192;
+		img.width = 192;
+
+		return img;
+	} else {
+		return getPicture({
+			opts: icons,
+			sizes: '10vmax',
+			alt: 'App Icon',
+		});
+	}
+}
+
+const beforeinstallprompt = new Promise(resolve => {
+	window.addEventListener('beforeinstallprompt', event => {
+		event.preventDefault();
+		resolve(event);
+	}, { once: true });
+});
+
+if ('serviceWorker' in navigator && 'serviceWorker' in document.documentElement.dataset) {
+	const { serviceWorker, scope = '/' } = document.documentElement.dataset;
+	navigator.serviceWorker.register(serviceWorker, { scope }).catch(console.error);
+
+	if ('reloadOnUpdate' in document.documentElement.dataset) {
+		navigator.serviceWorker.getRegistration().then(reg => {
+			reg.addEventListener('updatefound', async () => {
+				const [resp] = await Promise.all([
+					confirm('App updated in background. Would you like to reload to see updates?'),
+					reg.update(),
+				]);
+
+				if (resp === true) {
+					location.reload();
+				}
+			});
+		});
+	}
+}
+
+registerCustomElement('install-prompt', class HTMLInstallPromptElement extends HTMLElement {
+	constructor() {
+		super();
+		const shadow = this.attachShadow({ mode: 'closed' });
+
+		Promise.all([
+			getHTML(new URL('./components/install/prompt.html', meta.url)),
+			getManifest(),
+			loadStylesheet(new URL('./components/install/prompt.css', meta.url), { parent: shadow }),
+		]).then(async ([base, manifest]) => {
+			/**
+			 * @TODO: Handle `prefer_related_applications` somehow
+			 */
+			const { name, description, features, categories = [], screenshots = [], icons = [],
+				related_applications: relatedApps = [],/* prefer_related_applications: preferRelatedApps = false,*/
+			} = manifest;
+
+			if (Array.isArray(screenshots) && screenshots.length !==0) {
+				const screenshot = getPicture({
+					opts:         screenshots,
+					sizes:        '(max-width: 600px) 80vw, 40vw',
+					fallbackWidth: 640,
+				});
+
+				base.querySelector('[part="screenshots"]').replaceChildren(screenshot);
+			}
+
+			if (Array.isArray(icons) && icons.length !== 0) {
+				const icon = getIcon(...icons);
+				base.querySelector('[part="icon"]').replaceChildren(icon);
+			}
+
+			text('[part="name"]', name, { base });
+			text('[part="description"]', description, { base });
+			on(query('[data-click="close"]', base), { click: () => this.open = false });
+			on(query('[data-platform]', base), {
+				click: ({ target }) => {
+					const platform = target.closest('[data-platform]').dataset.platform;
+
+					if (hasGa()) {
+						send({
+							eventCategory: 'install',
+							eventAction: 'install',
+							eventLabel: platform,
+						});
+					}
+
+					this.dispatchEvent(new CustomEvent('install', { detail: { platform }}));
+				}
+			});
+
+			if (Array.isArray(features)) {
+				base.querySelector('[part="features"]').replaceChildren(...features.map(text => create('li', { text })));
+			}
+
+			if (Array.isArray(categories) && categories.length !== 0) {
+				base.querySelector('[part="categories"]')
+					.replaceChildren(...categories.map(text => create('li', { text, part: ['category'] })));
+			}
+
+			relatedApps.forEach(({ platform, url, id }) => {
+				switch(platform) {
+					case 'webapp':
+						Promise.resolve(base.querySelector('[data-platform="webapp"]')).then(btn => {
+							btn.hidden = false;
+
+							beforeinstallprompt.then(event => {
+								const installHandler = async () => {
+									const btns = query('[data-click="install"]', shadow);
+									btns.forEach(btn => btn.disabled = true);
+									off(btns, installHandler, { once: true });
+
+									await event.prompt();
+									const resp = await event.userChoice;
+
+									if (resp === 'accepted') {
+										this.open = false;
+									}
+								};
+
+								requestAnimationFrame(() => {
+									const btns = query('[data-click="install"]', shadow);
+
+									on(btns, 'click', installHandler, { once: true });
+									btns.forEach(btn => btn.disabled = false);
+								});
+							});
+						});
+						break;
+
+					case 'play':
+					case 'itunes':
+					case 'windows':
+						Promise.resolve(base.querySelector(`[data-platform="${platform}"]`)).then(btn => {
+							if (btn instanceof HTMLAnchorElement) {
+								const link = new URL(url, btn.href);
+
+								if (platform === 'play' && typeof id === 'string') {
+									link.searchParams.set('id', id);
+								}
+
+								btn.href = link.href;
+								btn.hidden = false;
+							}
+						});
+						break;
+				}
+			});
+
+			if (hasGa()) {
+				on(query('[data-platform]', base), {
+					click: ({ target }) => {
+						send({
+							eventCategory: 'install',
+							eventAction: 'install',
+							eventLabel: target.closest('[data-platform]').dataset.platform,
+						});
+					}
+				}, { once: true });
+			}
+
+			requestAnimationFrame(() => {
+				shadow.append(base);
+				this.dispatchEvent(new Event('ready'));
+			});
+		});
+	}
+
+	async attributeChangedCallback(attr, oldVal, newVal) {
+		switch(attr) {
+			case 'open':
+				if (typeof newVal === 'string') {
+					this.dispatchEvent(new Event('open'));
+				} else {
+					this.dispatchEvent(new Event('close'));
+				}
+				break;
+
+			default:
+				throw new DOMException(`Invalid attribute change handled: ${attr}`);
+		}
+	}
+
+	async show({ removeOnClose = true } = {}) {
+		if (! this.isConnected) {
+			document.body.append(this);
+		}
+
+		this.open = true;
+
+		if (removeOnClose) {
+			on(this, { close: ({ target }) => target.remove() }, { once: true });
+		}
+
+		return await new Promise((resolve, reject) => {
+			const handlers = {
+				install: ({ detail: { platform }}) => {
+					off(this, handlers, { once: true });
+					resolve({ platform });
+					this.close();
+				},
+				close: () => {
+					off(this, handlers, { once: true });
+					reject(new DOMException('User cancelled install prompt'));
+				},
+			};
+
+			on(this, handlers, { once: true });
+		});
+	}
+
+	async close() {
+		this.open = false;
+	}
+
+	get open() {
+		return this.hasAttribute('open');
+	}
+
+	set open(val) {
+		this.toggleAttribute('open', val);
+	}
+
+	static get observedAttributes() {
+		return ['open'];
+	}
+
+	static get serviceWorker() {
+		if ('serviceWorker' in navigator) {
+			return navigator.serviceWorker.getRegistration();
+		} else {
+			return null;
+		}
+	}
+});


### PR DESCRIPTION
This is much like the `<button is="pwa-install">` and `<pwa-prompt>` elements, except that it does not rely on the `beforeinstallprompt` event and does not use custom elements that extend built-in elements, making it better at discoverability and compatibility.