### PR TITLE
Revert "Make links open in new tab"

### DIFF
--- a/components/krv/events.html
+++ b/components/krv/events.html
@@ -4,7 +4,7 @@
 		<meta charset="utf-8" />
 	</head>
 	<body>
-		<a class="app-link" href="https://events.kernvalley.us/" target="_blank" rel="noopener noreferrer external">
+		<a class="app-link" href="https://events.kernvalley.us/" rel="noopener noreferrer external">
 			<h2 class="center" part="title">
 				<slot name="title">KRV Events Calendar</slot>
 				<svg width="12" height="16" fill="currentColor" viewBox="0 0 12 16" part="icon link-icon">
@@ -16,7 +16,7 @@
 		<template id="event-template">
 			<div class="container">
 				<h3 part="name">
-					<a href="" class="event-url" target="_blank" rel="noopener noreferrer external">
+					<a href="" class="event-url" rel="noopener noreferrer external">
 						<span class="event-name">Untitled Event</span>
 						<svg width="12" height="16" fill="currentColor" viewBox="0 0 12 16" part="icon link-icon">
 							<path fill-rule="evenodd" d="M11 10h1v3c0 .55-.45 1-1 1H1c-.55 0-1-.45-1-1V3c0-.55.45-1 1-1h3v1H1v10h10v-3zM6 2l2.25 2.25L5 7.5 6.5 9l3.25-3.25L12 8V2H6z"/>


### PR DESCRIPTION
Reverts shgysk8zer0/cdn.kernvalley.us#569

Turns out `<iframe>`s cannot open links in new tabs either. Will just need to use `sandbox="allow-scripts allow-top-navigation-by-user-activation"`.