### PR TITLE
Fix `utm_medium` default value

### DIFF
--- a/components/app/list-button.js
+++ b/components/app/list-button.js
@@ -116,7 +116,7 @@ registerCustomElement('app-list', class HTMLKernValleyAppListButtonlement extend
 	}
 
 	get medium() {
-		return this.getAttribute('medium') || 'web';
+		return this.getAttribute('medium') || 'referral';
 	}
 
 	set medium(value) {


### PR DESCRIPTION
Use `"referral"` instead of `"web"` by default.