### PR TITLE
Implement support for Trusted Types

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -29,6 +29,8 @@
         "no-prototype-builtins": 0
     },
     "globals": {
-      "cookieStore": "readonly"
+      "cookieStore": "readonly",
+      "globalThis": "readonly",
+      "Sanitizer": "readonly"
     }
 }

--- a/_headers
+++ b/_headers
@@ -2,7 +2,7 @@
   X-Frame-Options: DENY
   X-XSS-Protection: 1; mode=block
   Referrer-Policy: no-referrer
-  Content-Security-Policy: default-src 'self';  style-src 'self' cdn.kernvalley.us unpkg.com; script-src 'self' 'unsafe-inline' cdn.kernvalley.us unpkg.com www.gstatic.com/firebasejs/; connect-src 'self' *.kernvalley.us api.github.com api.openweathermap.org/data/ baconipsum.com/api/; img-src *; media-src *; font-src 'self' cdn.kernvalley.us; require-trusted-types-for 'script'; trusted-types default empty#html empty#script sanitizer#html; upgrade-insecure-requests;
+  Content-Security-Policy: default-src 'self';  style-src 'self' cdn.kernvalley.us unpkg.com; script-src 'self' 'unsafe-inline' cdn.kernvalley.us unpkg.com www.gstatic.com/firebasejs/; connect-src 'self' *.kernvalley.us api.github.com api.openweathermap.org/data/ baconipsum.com/api/; img-src *; media-src *; font-src 'self' cdn.kernvalley.us; require-trusted-types-for 'script'; trusted-types default empty#html empty#script sanitizer#html dompurify; upgrade-insecure-requests;
 
 /img/sprites.svg
   Referrer-Policy: no-referrer

--- a/_headers
+++ b/_headers
@@ -2,7 +2,7 @@
   X-Frame-Options: DENY
   X-XSS-Protection: 1; mode=block
   Referrer-Policy: no-referrer
-  Content-Security-Policy: default-src 'self';  style-src 'self' cdn.kernvalley.us unpkg.com; script-src 'self' 'unsafe-inline' cdn.kernvalley.us unpkg.com www.googletagmanager.com/gtag/ www.google-analytics.com/analytics.js www.gstatic.com/firebasejs/; connect-src 'self' *.kernvalley.us api.github.com api.openweathermap.org/data/ baconipsum.com/api/; img-src *; media-src *; font-src 'self' cdn.kernvalley.us; require-trusted-types-for 'script'; trusted-types default empty#html empty#script  purify-raw#html purify#html dompurify; upgrade-insecure-requests;
+  Content-Security-Policy: default-src 'self';  style-src 'self' cdn.kernvalley.us unpkg.com; script-src 'self' 'unsafe-inline' cdn.kernvalley.us unpkg.com www.googletagmanager.com/gtag/ www.google-analytics.com/analytics.js www.gstatic.com/firebasejs/; connect-src 'self' *.kernvalley.us api.github.com api.openweathermap.org/data/ baconipsum.com/api/; img-src *; media-src *; font-src 'self' cdn.kernvalley.us; require-trusted-types-for 'script'; trusted-types default empty#html empty#script fetch#html sanitizer-raw#html sanitizer#html purify-raw#html purify#html dompurify; upgrade-insecure-requests;
 
 /sw.js
   Referrer-Policy: no-referrer

--- a/_headers
+++ b/_headers
@@ -2,7 +2,7 @@
   X-Frame-Options: DENY
   X-XSS-Protection: 1; mode=block
   Referrer-Policy: no-referrer
-  Content-Security-Policy: default-src 'self';  style-src 'self' cdn.kernvalley.us unpkg.com; script-src 'self' 'unsafe-inline' cdn.kernvalley.us unpkg.com www.googletagmanager.com/gtag/ www.google-analytics.com/analytics.js www.gstatic.com/firebasejs/; connect-src 'self' *.kernvalley.us api.github.com api.openweathermap.org/data/ baconipsum.com/api/; img-src *; media-src *; font-src 'self' cdn.kernvalley.us; require-trusted-types-for 'script'; trusted-types default empty#html empty#script fetch#html sanitizer-raw#html sanitizer#html purify-raw#html purify#html dompurify; upgrade-insecure-requests;
+  Content-Security-Policy: default-src 'self';  style-src 'self' cdn.kernvalley.us unpkg.com; script-src 'self' 'unsafe-inline' cdn.kernvalley.us unpkg.com www.googletagmanager.com/gtag/ www.google-analytics.com/analytics.js www.gstatic.com/firebasejs/; connect-src 'self' *.kernvalley.us api.github.com api.openweathermap.org/data/ baconipsum.com/api/; img-src *; media-src *; font-src 'self' cdn.kernvalley.us; require-trusted-types-for 'script'; trusted-types default empty#html empty#script  purify-raw#html purify#html dompurify; upgrade-insecure-requests;
 
 /sw.js
   Referrer-Policy: no-referrer

--- a/_headers
+++ b/_headers
@@ -2,7 +2,7 @@
   X-Frame-Options: DENY
   X-XSS-Protection: 1; mode=block
   Referrer-Policy: no-referrer
-  Content-Security-Policy: default-src 'self';  style-src 'self' cdn.kernvalley.us unpkg.com; script-src 'self' 'unsafe-inline' cdn.kernvalley.us unpkg.com www.googletagmanager.com/gtag/ www.google-analytics.com/analytics.js www.gstatic.com/firebasejs/; connect-src 'self' *.kernvalley.us api.github.com api.openweathermap.org/data/ baconipsum.com/api/; img-src *; media-src *; font-src 'self' cdn.kernvalley.us; require-trusted-types-for 'script'; trusted-types default goog#html empty#html empty#script sanitizer#html dompurify; upgrade-insecure-requests;
+  Content-Security-Policy: default-src 'self';  style-src 'self' cdn.kernvalley.us unpkg.com; script-src 'self' 'unsafe-inline' cdn.kernvalley.us unpkg.com www.googletagmanager.com/gtag/ www.google-analytics.com/analytics.js www.gstatic.com/firebasejs/; connect-src 'self' *.kernvalley.us api.github.com api.openweathermap.org/data/ baconipsum.com/api/; img-src *; media-src *; font-src 'self' cdn.kernvalley.us; require-trusted-types-for 'script'; trusted-types default empty#html empty#script fetch#html sanitizer-raw#html sanitizer#html purify-raw#html purify#html dompurify; upgrade-insecure-requests;
 
 /sw.js
   Referrer-Policy: no-referrer

--- a/_headers
+++ b/_headers
@@ -2,7 +2,11 @@
   X-Frame-Options: DENY
   X-XSS-Protection: 1; mode=block
   Referrer-Policy: no-referrer
-  Content-Security-Policy: default-src 'self';  style-src 'self' cdn.kernvalley.us unpkg.com; script-src 'self' 'unsafe-inline' cdn.kernvalley.us unpkg.com www.gstatic.com/firebasejs/; connect-src 'self' *.kernvalley.us api.github.com api.openweathermap.org/data/ baconipsum.com/api/; img-src *; media-src *; font-src 'self' cdn.kernvalley.us; require-trusted-types-for 'script'; trusted-types default empty#html empty#script sanitizer#html dompurify; upgrade-insecure-requests;
+  Content-Security-Policy: default-src 'self';  style-src 'self' cdn.kernvalley.us unpkg.com; script-src 'self' 'unsafe-inline' cdn.kernvalley.us unpkg.com www.googletagmanager.com/gtag/ www.google-analytics.com/analytics.js www.gstatic.com/firebasejs/; connect-src 'self' *.kernvalley.us api.github.com api.openweathermap.org/data/ baconipsum.com/api/; img-src *; media-src *; font-src 'self' cdn.kernvalley.us; require-trusted-types-for 'script'; trusted-types default goog#html empty#html empty#script sanitizer#html dompurify; upgrade-insecure-requests;
+
+/sw.js
+  Referrer-Policy: no-referrer
+  Content-Security-Poliy: default-src 'self'; connect-src *;
 
 /img/sprites.svg
   Referrer-Policy: no-referrer

--- a/_headers
+++ b/_headers
@@ -2,7 +2,7 @@
   X-Frame-Options: DENY
   X-XSS-Protection: 1; mode=block
   Referrer-Policy: no-referrer
-  Content-Security-Policy: default-src 'self';  style-src 'self' cdn.kernvalley.us unpkg.com; script-src 'self' 'unsafe-inline' cdn.kernvalley.us unpkg.com www.gstatic.com/firebasejs/; connect-src 'self' *.kernvalley.us api.github.com api.openweathermap.org/data/ baconipsum.com/api/; img-src *; media-src *; font-src 'self' cdn.kernvalley.us; upgrade-insecure-requests;
+  Content-Security-Policy: default-src 'self';  style-src 'self' cdn.kernvalley.us unpkg.com; script-src 'self' 'unsafe-inline' cdn.kernvalley.us unpkg.com www.gstatic.com/firebasejs/; connect-src 'self' *.kernvalley.us api.github.com api.openweathermap.org/data/ baconipsum.com/api/; img-src *; media-src *; font-src 'self' cdn.kernvalley.us; require-trusted-types-for 'script'; trusted-types default empty#html empty#script sanitizer#html; upgrade-insecure-requests;
 
 /img/sprites.svg
   Referrer-Policy: no-referrer

--- a/components/ad/block.js
+++ b/components/ad/block.js
@@ -8,10 +8,11 @@ import { getHTML } from '../../js/std-js/http.js';
 import { meta } from '../../import.meta.js';
 import { getDeferred } from '../../js/std-js/promises.js';
 import UTM from '../../js/std-js/UTM.js';
+import { purify as policy } from '../../js/std-js/purify.js';
 
 const { resolve, promise: def } = getDeferred();
 
-const templatePromise = def.then(() => getHTML(new URL('./components/ad/block.html', meta.url)));
+const templatePromise = def.then(() => getHTML(new URL('./components/ad/block.html', meta.url), { policy }));
 
 async function getTemplate() {
 	resolve();

--- a/components/github/user.js
+++ b/components/github/user.js
@@ -3,10 +3,12 @@ import { getJSON, getHTML } from '../../js/std-js/http.js';
 import { meta } from '../../import.meta.js';
 import { loadStylesheet } from '../../js/std-js/loader.js';
 import { getDeferred } from '../../js/std-js/promises.js';
+import { purify as policy } from '../../js/std-js/purify.js';
+
 const ENDPOINT = 'https://api.github.com';
 import HTMLCustomElement from '../custom-element.js';
 const { resolve, promise: def } = getDeferred();
-const templatePromise = def.then(() => getHTML(new URL('./components/github/user.html', meta.url)));
+const templatePromise = def.then(() => getHTML(new URL('./components/github/user.html', meta.url), { policy }));
 
 async function getTemplate() {
 	resolve();

--- a/components/install/prompt.js
+++ b/components/install/prompt.js
@@ -6,11 +6,13 @@ import { query, create, text, on, off } from '../../js/std-js/dom.js';
 import { hasGa, send } from '../../js/std-js/google-analytics.js';
 import { registerButton } from '../../js/std-js/pwa-install.js';
 import { manifestPromise, getDeferred } from '../../js/std-js/promises.js';
-import '../notification/html-notification.js';
+import { purify as policy } from '../../js/std-js/purify.js';
 const { resolve, promise: def } = getDeferred();
+
+import '../notification/html-notification.js';
 const getManifest = async () => await manifestPromise;
 
-const templatePromise = def.then(() => getHTML(new URL('./components/install/prompt.html', meta.url)));
+const templatePromise = def.then(() => getHTML(new URL('./components/install/prompt.html', meta.url), { policy }));
 
 async function getTemplate() {
 	resolve();

--- a/components/krv/events.js
+++ b/components/krv/events.js
@@ -4,7 +4,17 @@ import { registerCustomElement } from '../../js/std-js/custom-elements.js';
 import { loadStylesheet } from '../../js/std-js/loader.js';
 import { hasGa, send } from '../../js/std-js/google-analytics.js';
 import { meta } from '../../import.meta.js';
+import { getDeferred } from '../../js/std-js/promises.js';
+import { purify as policy } from '../../js/std-js/purify.js';
 
+const { resolve, promise: def } = getDeferred();
+const templatePromise = def.then(() => getHTML(new URL('./components/krv/events.html', meta.url), { policy }));
+
+async function getTemplate() {
+	resolve();
+	const tmp = await templatePromise;
+	return tmp.cloneNode(true);
+}
 const protectedData = new WeakMap();
 
 function utm(url, { campaign, content, medium, source, term }) {
@@ -42,7 +52,7 @@ registerCustomElement('krv-events', class HTMLKRVEventsElement extends HTMLEleme
 		const parent = this.attachShadow({ mode: 'closed' });
 
 		Promise.all([
-			getHTML(new URL('./components/krv/events.html', meta.url).href),
+			getTemplate(),
 			loadStylesheet(new URL('./components/krv/events.css', meta.url).href, { parent }),
 			this.whenConnected,
 		]).then(([frag]) => {

--- a/components/notification/html-notification.js
+++ b/components/notification/html-notification.js
@@ -1,5 +1,6 @@
 import HTMLCustomElement from '../custom-element.js';
 import { getDeferred } from '../../js/std-js/promises.js';
+import { purify as policy } from '../../js/std-js/purify.js';
 
 function getSlot(name, base) {
 	const slot = base.shadowRoot.querySelector(`slot[name="${name}"]`);
@@ -56,7 +57,7 @@ export class HTMLNotificationElement extends HTMLCustomElement {
 			this.onerror = null;
 		});
 
-		this.getTemplate('./components/notification/html-notification.html', { signal }).then(tmp => {
+		this.getTemplate('./components/notification/html-notification.html', { signal, policy }).then(tmp => {
 			tmp.querySelector('[part="close"]').addEventListener('click', () => this.close(), {
 				capture: true,
 				once: true,

--- a/components/popup/html-popup.js
+++ b/components/popup/html-popup.js
@@ -1,4 +1,5 @@
 import HTMLCustomElement from '../custom-element.js';
+import { purify as policy } from '../../js/std-js/purify.js';
 
 HTMLCustomElement.register('html-popup', class HTMLPopupElement extends HTMLCustomElement {
 	constructor(content = null, {
@@ -11,7 +12,7 @@ HTMLCustomElement.register('html-popup', class HTMLPopupElement extends HTMLCust
 		this.attachShadow({ mode: 'open' });
 		this.addEventListener('click', () => this.close(), { passive: true, capture: true });
 
-		this.getTemplate('./components/popup/html-popup.html').then(tmp => {
+		this.getTemplate('./components/popup/html-popup.html', { policy }).then(tmp => {
 			this.shadowRoot.append(tmp);
 			this.dispatchEvent(new Event('ready'));
 		});

--- a/components/pwa/prompt.js
+++ b/components/pwa/prompt.js
@@ -2,10 +2,14 @@ import HTMLCustomElement from '../custom-element.js';
 import { registerButton } from '../../js/pwa-install.js';
 import { getHTML } from '../../js/std-js/http.js';
 import { meta } from '../../import.meta.js';
+import { getDeferred } from '../../js/std-js/promises.js';
+import { purify as policy } from '../../js/std-js/purify.js';
+const { resolve, promise: def } = getDeferred();
 
-const templatePromise = getHTML(new URL('./components/pwa/prompt.html', meta.url));
+const templatePromise = def.then(() => getHTML(new URL('./components/pwa/prompt.html', meta.url),  { policy }));
 
 async function getTemplate() {
+	resolve();
 	const tmp = await templatePromise;
 	return tmp.cloneNode(true);
 }

--- a/components/scroll-progress/scroll-progress.js
+++ b/components/scroll-progress/scroll-progress.js
@@ -1,4 +1,4 @@
-/* global ScrollTimeline, CSSUnitValue, globalThis */
+/* global ScrollTimeline, CSSUnitValue */
 import { css } from '../../js/std-js/dom.js';
 import { loadScript } from '../../js/std-js/loader.js';
 import { registerCustomElement } from '../../js/std-js/custom-elements.js';

--- a/components/scroll-progress/scroll-progress.js
+++ b/components/scroll-progress/scroll-progress.js
@@ -7,7 +7,7 @@ const POLYFILL = 'https://flackr.github.io/scroll-timeline/dist/scroll-timeline.
 
 registerCustomElement('scroll-progress', class HTMLScrollProgressElement extends HTMLElement {
 	async connectedCallback() {
-		if ('ScrollTimeline' in globalThis) {
+		if (HTMLScrollProgressElement.supported) {
 			const shadow = this.attachShadow({ mode: 'closed' });
 			const progress = document.createElement('div');
 			progress.setAttribute('part', 'progress');

--- a/components/share-to-button/share-to-button.js
+++ b/components/share-to-button/share-to-button.js
@@ -8,9 +8,10 @@ import { loadStylesheet } from '../../js/std-js/loader.js';
 import { Facebook, Twitter, Reddit, LinkedIn, Gmail, Pinterest, Email, Tumblr, Telegram, getShareURL }
 	from '../../js/std-js/share-targets.js';
 
+import { purify as policy } from '../../js/std-js/purify.js';
 const { resolve, promise: def } = getDeferred();
 
-const templatePromise = def.then(() => getHTML(new URL('./components/share-to-button/share-to-button.html', meta.url)));
+const templatePromise = def.then(() => getHTML(new URL('./components/share-to-button/share-to-button.html', meta.url), { policy }));
 
 async function getTemplate() {
 	resolve();

--- a/components/slide-show/slide-show.js
+++ b/components/slide-show/slide-show.js
@@ -1,5 +1,6 @@
 import HTMLCustomElement from '../custom-element.js';
 import { sleep } from '../../js/std-js/promises.js';
+import { purify as policy } from '../../js/std-js/purify.js';
 
 async function visible() {
 	if (document.visibilityState === 'hidden') {
@@ -30,7 +31,7 @@ HTMLCustomElement.register('slide-show', class HTMLSlideShowElement extends HTML
 			}
 		});
 
-		this.getTemplate('./components/slide-show/slide-show.html').then(async tmp => {
+		this.getTemplate('./components/slide-show/slide-show.html', { policy }).then(async tmp => {
 			const actionHandler = async action => {
 				switch (action) {
 					case 'next':

--- a/components/spotify/player.js
+++ b/components/spotify/player.js
@@ -1,4 +1,5 @@
 import HTMLCustomElement from '../custom-element.js';
+import { purify as policy } from '../../js/std-js/purify.js';
 
 const SPOTIFY = 'https://open.spotify.com/embed/';
 const TYPES = [
@@ -68,7 +69,7 @@ HTMLCustomElement.register('spotify-player', class HTMLSpotifyTrackElement exten
 		super();
 		this.attachShadow({ mode: 'open' });
 
-		this.getTemplate('./components/spotify/player.html').then(tmp => {
+		this.getTemplate('./components/spotify/player.html', { policy }).then(tmp => {
 			this.shadowRoot.append(tmp.cloneNode(true));
 			this.dispatchEvent(new Event('ready'));
 		});

--- a/components/toast-message.js
+++ b/components/toast-message.js
@@ -1,4 +1,5 @@
 import HTMLCustomElement from './custom-element.js';
+import { purify as policy } from '../js/std-js/purify.js';
 
 HTMLCustomElement.register('toast-message', class HTMLToastMessageElement extends HTMLCustomElement {
 	constructor(message = null) {
@@ -9,7 +10,7 @@ HTMLCustomElement.register('toast-message', class HTMLToastMessageElement extend
 			this.hidden = ! this.open;
 		});
 
-		this.getTemplate(('./components/toast-message.html')).then(async frag => {
+		this.getTemplate(('./components/toast-message.html'), { policy }).then(async frag => {
 			frag.getElementById('close-toast-button').addEventListener('click', () => {
 				this.close();
 			}, {

--- a/components/weather/current.js
+++ b/components/weather/current.js
@@ -1,6 +1,8 @@
 import { shadows, clearSlot, getWeatherByPostalCode, createIcon, getIcon, getSprite } from './helper.js';
 import HTMLCustomElement from '../custom-element.js';
 
+import { purify as policy } from '../../js/std-js/purify.js';
+
 HTMLCustomElement.register('weather-current', class HTMLWeatherForecastElement extends HTMLCustomElement {
 	constructor({ appId = null, postalCode = null, loading = null } = {}) {
 		super();
@@ -21,7 +23,7 @@ HTMLCustomElement.register('weather-current', class HTMLWeatherForecastElement e
 
 			await Promise.all([this.whenConnected, this.whenLoad]);
 
-			const tmp = await this.getTemplate('./components/weather/current.html');
+			const tmp = await this.getTemplate('./components/weather/current.html', { policy });
 			shadow.append(tmp);
 			shadows.set(this, shadow);
 			this.dispatchEvent(new Event('ready'));

--- a/index.html
+++ b/index.html
@@ -65,6 +65,7 @@
 				<i>(JavaScript, Stylesheets, Images, &amp; Fonts)</i> are shared and accessible
 				on a number of different sites.
 			</blockquote>
+			<weather-forecast postalcode="93240" appid="6be145cbc5791c9f80471ff39d8523ed" theme="auto"></weather-forecast>
 			<div class="center">
 				<leaflet-map center="35.753003,-118.424572" zoom="13" crossorigin="anonymous" detectretina="" loading="lazy" router="" zoomcontrol="" data-markers="towns restaurants campgrounds stores landmarks"></leaflet-map>
 			</div>

--- a/index.html
+++ b/index.html
@@ -15,20 +15,7 @@
 		<link rel="preload" href="/components/share-to-button/share-to-button.html" as="fetch" type="text/html" referrerpolicy="no-referrer" />
 		<link rel="preload" href="/components/share-to-button/share-to-button.css" as="style" type="text/css" referrerpolicy="no-referrer" />
 		<link rel="preconnect" href="https://api.github.com" crossorigin="anonymous" referrerpolicy="no-referrer" />
-		<script type="module" src="/js/std-js/deprefixer.js" referrerpolicy="no-referrer"></script>
-		<script type="module" src="/js/std-js/shims.js" referrerpolicy="no-referrer"></script>
-		<script type="module" src="/components/current-year.js" referrerpolicy="no-referrer"></script>
-		<script type="module" src="/components/github/user.js" referrerpolicy="no-referrer"></script>
-		<script type="module" src="/components/ad/block.js" referrerpolicy="no-referrer"></script>
-		<script type="module" src="/components/share-button.js" referrerpolicy="no-referrer"></script>
-		<script type="module" src="/components/window-controls.js" referrerpolicy="no-referrer"></script>
-		<script type="module" src="/components/share-to-button/share-to-button.js" referrerpolicy="no-referrer"></script>
-		<script type="module" src="/components/weather/current.js" referrerpolicy="no-referrer"></script>
-		<script type="module" src="/components/leaflet/map.js" referrerpolicy="no-referrer"></script>
-		<script type="module" src="/components/leaflet/marker.js" referrerpolicy="no-referrer"></script>
-		<script type="module" src="/components/app/list-button.js" referrerpolicy="no-referrer"></script>
-		<script type="module" src="/components/app/stores.js" referrerpolicy="no-referrer"></script>
-		<script type="module" src="/js/std-js/theme-cookie.js" referrerpolicy="no-referrer"></script>
+		<script type="module" src="/index.js" referrerpolicy="no-referrer"></script>
 		<link rel="stylesheet" href="/css/core-css/theme/properties.css" referrerpolicy="no-referrer" media="screen" />
 		<link rel="stylesheet" title="Adwaita Theme" href="/css/core-css/theme/adwaita/index.css" referrerpolicy="no-referrer" media="screen" />
 		<link rel="alternate stylesheet" title="Default Theme" href="/css/core-css/theme/default/index.css" referrerpolicy="no-referrer" media="screen" />
@@ -60,7 +47,7 @@
 					</svg>
 				</button>
 				<img src="/img/branding/kernvalley.us.svg" alt="logo" height="32" width="32" loading="lazy" />
-				<b >KernValley.US CDN</b>
+				<b>KernValley.US CDN</b>
 			</div>
 		</window-controls>
 		<nav id="nav" class="contain-content background-primary adwaita-toolbar sticky top shadow z-4 flex row no-wrap overflow-x-auto">

--- a/index.html
+++ b/index.html
@@ -29,9 +29,6 @@
 		<link rel="stylesheet" href="/css/core-css/forms.css" referrerpolicy="no-referrer" />
 		<link rel="stylesheet" href="/css/core-css/layout/right-sidebar/index.css" referrerpolicy="no-referrer" media="screen" />
 		<title>KernValley.us | CDN</title>
-		<script type="module">
-			navigator.serviceWorker.register('/sw.js').catch(console.error);
-		</script>
 	</head>
 	<body class="grid border-box background-primary color-default font-main">
 		<header id="header" class="contain-content center">

--- a/index.js
+++ b/index.js
@@ -1,10 +1,12 @@
 import './js/std-js/deprefixer.js';
 import './js/std-js/shims.js';
+import './js/std-js/shims/sanitizer.js';
+import './js/std-js/shims/trustedTypes.js';
+import './js/std-js/shims/locks.js';
+import './js/std-js/shims/cookieStore.js';
 // import { polyfill as trustPolyfill } from './js/std-js/TrustedTypes.js';
-import { polyfill as locksPolyfill } from './js/std-js/LockManager.js';
-import { Sanitizer as SanitizerShim } from './js/std-js/Sanitizer.js';
 import { loadScript } from './js/std-js/loader.js';
-import { SanitizerConfig as config } from './js/std-js/SanitizerConfig.js';
+// import { SanitizerConfig as config } from './js/std-js/SanitizerConfig.js';
 import { enforce } from './js/std-js/trust-enforcer.js';
 import { createPolicy } from './js/std-js/trust.js';
 const modules = [
@@ -15,24 +17,26 @@ const modules = [
 	'./components/window-controls.js',
 	'./components/share-to-button/share-to-button.js',
 	'./components/weather/current.js',
+	'./components/weather/forecast.js',
 	'./components/leaflet/map.js',
 	'./components/leaflet/marker.js',
 	'./components/app/list-button.js',
 	'./components/app/stores.js',
+	'./components/notification/html-notification.js',
 	'./js/std-js/theme-cookie.js',
 ];
 
-if (! ('Sanitizer' in globalThis && globalThis.Sanitizer.prototype.getConfiguration instanceof Function)) {
-	globalThis.Sanitizer = SanitizerShim;
-}
-
-const sanitizer = new globalThis.Sanitizer(config);
+// const sanitizer = new globalThis.Sanitizer(config);
 
 const policy = createPolicy('default', {
-	createHTML: input => sanitizer.sanitizeFor('div', input).innerHTML,
-	createScript: input => {
-		throw new DOMException(`Untrusted attempt to create script: "${input}"`);
+	createHTML: input => {
+		console.info(input);
+		console.trace();
+		return new Sanitizer().sanitizeFor('div', input).innerHTML;
 	},
+	// createScript: input => {
+	// 	throw new DOMException(`Untrusted attempt to create script: "${input}"`);
+	// },
 	createScriptURL: input => {
 		if ([location.origin, 'https://cdn.kernvalley.us'].includes(new URL(input, document.baseURI).origin)) {
 			return input;
@@ -42,10 +46,8 @@ const policy = createPolicy('default', {
 	}
 });
 
-enforce([policy.name, 'sanitize#html', 'empty#html', 'empty#script', 'dompurify']);
 Promise.allSettled([
 	// trustPolyfill(),
-	locksPolyfill(),
 	navigator.serviceWorker.register(policy.createScriptURL('/sw.js')).catch(console.error),
 	...modules.map(src => loadScript(policy.createScriptURL(new URL(src, document.baseURI)), { type: 'module' }))
 ]);

--- a/index.js
+++ b/index.js
@@ -2,7 +2,6 @@ import './js/std-js/deprefixer.js';
 import './js/std-js/shims.js';
 import { polyfill as trustPolyfill } from './js/std-js/TrustedTypes.js';
 import { polyfill as locksPolyfill } from './js/std-js/LockManager.js';
-import { creatPolicy } from './js/std-js/trust.js';
 import { loadScript } from './js/std-js/loader.js';
 const modules = [
 	'./components/current-year.js',
@@ -24,11 +23,11 @@ document.addEventListener('securitypolicyviolation', console.error);
 Promise.allSettled([
 	trustPolyfill(),
 	locksPolyfill(),
+	navigator.serviceWorker.register('/sw.js').catch(console.error),
 ]).then(async () => {
-	const { polyfill: sanitizerPolyfill } = await import(new URL('./js/std-js/Sanitizer.js', import.meta.url));
-	await sanitizerPolyfill();
+	const { Sanitizer } = await import(new URL('./js/std-js/Sanitizer.js', import.meta.url));
 	const sanitizer = new Sanitizer({...Sanitizer.getDefaultConfiguration(), allowCustomElements: true });
-	const policy = createPolicy('default', {
+	const policy = globalThis.trustedTypes.createPolicy('default', {
 		createHTML: input => sanitizer.sanitizeFor('div').innerHTML,
 		createScriptURL: input => {
 			if ([location.origin, 'https://cdn.kernvalley.us'].includes(new URL(input).origin)) {
@@ -40,6 +39,6 @@ Promise.allSettled([
 	});
 
 	await Promise.allSettled(
-		modules.map(src => loadScript(policy.createScriptURL(src), { type: 'module' }))
+		modules.map(src => loadScript(policy.createScriptURL(new URL(src, document.baseURI)), { type: 'module' }))
 	).then(console.info);
 });

--- a/index.js
+++ b/index.js
@@ -30,9 +30,11 @@ const modules = [
 
 const policy = createPolicy('default', {
 	createHTML: input => {
-		console.info(input);
-		console.trace();
-		return new Sanitizer().sanitizeFor('div', input).innerHTML;
+		if (input.includes('<')) {
+			return new Sanitizer().sanitizeFor('div', input).innerHTML;
+		} else {
+			return input;
+		}
 	},
 	// createScript: input => {
 	// 	throw new DOMException(`Untrusted attempt to create script: "${input}"`);

--- a/index.js
+++ b/index.js
@@ -4,8 +4,8 @@ import './js/std-js/shims.js';
 import { polyfill as locksPolyfill } from './js/std-js/LockManager.js';
 import { Sanitizer as SanitizerShim } from './js/std-js/Sanitizer.js';
 import { loadScript } from './js/std-js/loader.js';
-import { SanitizerConfig as config } from './js/std-js/SanitizerConfigBase.js';
-// import { enforce } from './js/std-js/trust-enforcer.js';
+import { SanitizerConfig as config } from './js/std-js/SanitizerConfig.js';
+import { enforce } from './js/std-js/trust-enforcer.js';
 import { createPolicy } from './js/std-js/trust.js';
 const modules = [
 	'./components/current-year.js',
@@ -22,36 +22,14 @@ const modules = [
 	'./js/std-js/theme-cookie.js',
 ];
 
-let shimmed = false;
 if (! ('Sanitizer' in globalThis && globalThis.Sanitizer.prototype.getConfiguration instanceof Function)) {
 	globalThis.Sanitizer = SanitizerShim;
-	shimmed = true;
 }
 
-const sanitizer = shimmed === false ? new globalThis.Sanitizer({
-	allowElements: [...Sanitizer.getDefaultConfiguration().allowElements, 'slot', 'svg', 'svg:*'],
-	allowAttributes: {...Sanitizer.getDefaultConfiguration().allowAttributes },
-	blockElements: Sanitizer.getDefaultConfiguration().blockElements,
-	dropAttributes: Sanitizer.getDefaultConfiguration().dropAttributes,
-	dropElements: Sanitizer.getDefaultConfiguration().dropElements,
-	allowCustomElements: true,
-}): new globalThis.Sanitizer({
-	allowElements: [...config.allowElements, 'slot', 'svg', 'svg:*'],
-	allowAttributes: config.allowAttributes,
-	blockElements: config.blockElements,
-	dropAttributes: config.dropAttributes,
-	dropElements: ['script'],
-	allowCustomElements: true,
-});
-console.log(sanitizer.getConfiguration());
+const sanitizer = new globalThis.Sanitizer(config);
+
 const policy = createPolicy('default', {
-	createHTML: input => {
-		const output = sanitizer.sanitizeFor('div', input).innerHTML;
-		if (input !== output) {
-			console.log({ input, output });
-		}
-		return output;
-	},
+	createHTML: input => sanitizer.sanitizeFor('div', input).innerHTML,
 	createScript: input => {
 		throw new DOMException(`Untrusted attempt to create script: "${input}"`);
 	},
@@ -64,17 +42,10 @@ const policy = createPolicy('default', {
 	}
 });
 
-console.log({ policy });
+enforce([policy.name, 'sanitize#html', 'empty#html', 'empty#script', 'dompurify']);
 Promise.allSettled([
 	// trustPolyfill(),
 	locksPolyfill(),
-	navigator.serviceWorker.register('/sw.js').catch(console.error),
-]).then(async () => {
-	// const { Sanitizer } = await import(new URL('./js/std-js/Sanitizer.js', import.meta.url));
-
-	// enforce([policy.name, 'sanitize#html', 'empty#html', 'empty#script']);
-
-	await Promise.allSettled(
-		modules.map(src => loadScript(policy.createScriptURL(new URL(src, document.baseURI)), { type: 'module' }))
-	).then(console.info);
-});
+	navigator.serviceWorker.register(policy.createScriptURL('/sw.js')).catch(console.error),
+	...modules.map(src => loadScript(policy.createScriptURL(new URL(src, document.baseURI)), { type: 'module' }))
+]);

--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ import './js/std-js/shims.js';
 import { polyfill as trustPolyfill } from './js/std-js/TrustedTypes.js';
 import { polyfill as locksPolyfill } from './js/std-js/LockManager.js';
 import { loadScript } from './js/std-js/loader.js';
+import { enforce } from './js/std-js/trust-enforcer.js';
 const modules = [
 	'./components/current-year.js',
 	'./components/github/user.js',
@@ -37,6 +38,8 @@ Promise.allSettled([
 			}
 		}
 	});
+
+	enforce([policy.name, 'sanitize#html', 'empty#html', 'empty#script']);
 
 	await Promise.allSettled(
 		modules.map(src => loadScript(policy.createScriptURL(new URL(src, document.baseURI)), { type: 'module' }))

--- a/index.js
+++ b/index.js
@@ -1,0 +1,45 @@
+import './js/std-js/deprefixer.js';
+import './js/std-js/shims.js';
+import { polyfill as trustPolyfill } from './js/std-js/TrustedTypes.js';
+import { polyfill as locksPolyfill } from './js/std-js/LockManager.js';
+import { creatPolicy } from './js/std-js/trust.js';
+import { loadScript } from './js/std-js/loader.js';
+const modules = [
+	'./components/current-year.js',
+	'./components/github/user.js',
+	'./components/ad/block.js',
+	'./components/share-button.js',
+	'./components/window-controls.js',
+	'./components/share-to-button/share-to-button.js',
+	'./components/weather/current.js',
+	'./components/leaflet/map.js',
+	'./components/leaflet/marker.js',
+	'./components/app/list-button.js',
+	'./components/app/stores.js',
+	'./js/std-js/theme-cookie.js',
+];
+
+document.addEventListener('securitypolicyviolation', console.error);
+
+Promise.allSettled([
+	trustPolyfill(),
+	locksPolyfill(),
+]).then(async () => {
+	const { polyfill: sanitizerPolyfill } = await import(new URL('./js/std-js/Sanitizer.js', import.meta.url));
+	await sanitizerPolyfill();
+	const sanitizer = new Sanitizer({...Sanitizer.getDefaultConfiguration(), allowCustomElements: true });
+	const policy = createPolicy('default', {
+		createHTML: input => sanitizer.sanitizeFor('div').innerHTML,
+		createScriptURL: input => {
+			if ([location.origin, 'https://cdn.kernvalley.us'].includes(new URL(input).origin)) {
+				return input;
+			} else {
+				throw new DOMException('Untrusted script src');
+			}
+		}
+	});
+
+	await Promise.allSettled(
+		modules.map(src => loadScript(policy.createScriptURL(src), { type: 'module' }))
+	).then(console.info);
+});

--- a/sri/index.css
+++ b/sri/index.css
@@ -1,0 +1,41 @@
+:root {
+	accent-color: var(--accent-color);
+}
+
+#main {
+	padding: 1.2rem;
+	display: flex;
+	justify-content: center;
+}
+
+#request {
+	margin: 16px;
+	max-width: 800px;
+	flex-grow: 1;
+}
+
+#hash {
+	max-width: 85vw;
+	overflow: auto;
+}
+
+#copy-btn {
+	padding: 12px 28px;
+	border-radius: 6px;
+}
+
+.output {
+	gap: 12px;
+}
+
+.btns {
+	gap: 8px;
+	justify-content: space-evenly;
+}
+
+.btns .btn {
+	flex-grow: 1;
+	max-width: 180px;
+	padding: 12px;
+	border-radius: 6px;
+}

--- a/sri/index.html
+++ b/sri/index.html
@@ -1,0 +1,74 @@
+<!DOCTYPE html>
+<html lang="en" dir="ltr">
+	<head>
+		<meta charset="utf-8" />
+		<meta name="color-scheme" content="light dark" />
+		<meta name="viewport" content="width=device-width" />
+		<title>SRI Generator</title>
+		<base href="/sri/" />
+		<link rel="manifest" href="/webapp.webmanifest" />
+		<link rel="icon" href="/img/kernvalley-icons/kernvalley.svg" type="image/svg+xml" />
+		<link rel="preconnect" href="https://api.github.com" crossorigin="anonymous" referrerpolicy="no-referrer" />
+		<link rel="preload" href="/components/github/user.html" as="fetch" type="text/html" referrerpolicy="no-referrer" />
+		<link rel="preload" href="/components/github/user.css" as="style" type="text/css" referrerpolicy="no-referrer" />
+		<script type="module" src="/js/std-js/shims.js" referrerpolicy="no-referrer"></script>
+		<script type="module" src="/sri/index.js" referrerpolicy="no-referrer"></script>
+		<script type="module" src="/components/github/user.js" referrerpolicy="no-referrer"></script>
+		<link rel="stylesheet" href="/sri/index.css" referrerpolicy="no-referrer" media="all" />
+		<link rel="stylesheet" href="/css/core-css/theme/default/index.css" referrerpolicy="no-referrer" media="all" />
+		<link rel="stylesheet" href="/css/core-css/element.css" referrerpolicy="no-referrer" media="all" />
+		<link rel="stylesheet" href="/css/core-css/class-rules.css" referrerpolicy="no-referrer" media="all" />
+		<link rel="stylesheet" href="/css/core-css/forms.css" referrerpolicy="no-referrer" media="all" />
+		<link rel="stylesheet" href="/css/core-css/accordion.css" referrerpolicy="no-referrer" media="all" />
+		<link rel="stylesheet" href="/css/core-css/fonts.css" referrerpolicy="no-referrer" media="all" />
+		<link rel="stylesheet" href="/css/core-css/scrollbar.css" referrerpolicy="no-referrer" media="all" />
+	</head>
+	<body class="background-primary color-default font-main border-box grid">
+		<dialog id="error-dialog">
+			<pre class="status-box error"><code id="error-msg"></code></pre>
+			<hr />
+			<div class="center">
+				<button type="button" class="btn btn-reject" data-close="#error-dialog">Close</button>
+			</div>
+		</dialog>
+		<header id="header"></header>
+		<main id="main">
+			<form id="request" class="card" autocomplete="off">
+				<fieldset class="no-border" disabled="">
+					<legend>Select a File</legend>
+					<div class="form-group">
+						<label for="file" class="input-label required">File</label>
+						<input type="file" name="file" id="file" class="input" accept="text/html text/css application/javascript application/json" required="" />
+					</div>
+					<details class="accordion">
+						<summary>Options</summary>
+						<div class="form-group">
+							<label for="algo" class="input-label required">Hashing Algo</label>
+							<select name="algo" id="algo" class="input" required="">
+								<option value="SHA-256">SHA-256</option>
+								<option value="SHA-384" selected="">SHA-384</option>
+								<option value="SHA-512">SHA-512</option>
+							</select>
+						</div>
+					</details>
+					<br />
+					<div class="flex row no-wrap output">
+						<output id="hash" class="grow-1">Generated hash will appear here</output>
+						<button type="button" id="copy-btn" class="btn btn-primary" disabled="">Copy</button>
+					</div>
+				</fieldset>
+				<hr />
+				<div class="flex row btns">
+					<button type="submit" class="btn btn-accept" disabled="">Hash</button>
+					<button type="reset" class="btn btn-reject" disabled="">Clear</button>
+				</div>
+			</form>
+		</main>
+		<footer id="footer">
+			<div class="flex row wrap space-evenly">
+				<github-user user="shgysk8zer0"></github-user>
+				<github-user user="kernvalley"></github-user>
+			</div>
+		</footer>
+	</body>
+</html>

--- a/sri/index.js
+++ b/sri/index.js
@@ -1,0 +1,68 @@
+import { fromFile } from '/js/std-js/integrity.js';
+import { enable, disable, on, ready, value } from '/js/std-js/dom.js';
+import { createPolicy } from '/js/std-js/trust.js';
+
+const policy = createPolicy('default', {
+	createScriptURL: input => {
+		if ([location.origin, 'https://cdn.kernvalley.us'].includes(new URL(input, location.origin).origin)) {
+			return input;
+		} else {
+			throw new DOMException(`Untrusted script url <${input}`);
+		}
+	}
+});
+
+navigator.serviceWorker.register(policy.createScriptURL('/sw.js')).catch(console.error);
+
+ready().then(async () => {
+	on('#copy-btn', {
+		click: async () => {
+			await navigator.clipboard.writeText(document.getElementById('hash').value);
+		}
+	});
+
+	on('[data-close]', {
+		click: function() {
+			document.querySelectorAll(this.dataset.close).forEach(el => el.close());
+		}
+	});
+
+	on(document.forms.request, {
+		submit: async event => {
+			event.preventDefault();
+			const data = new FormData(event.target);
+			disable('.btn-accept, fieldset');
+			const controller = new AbortController();
+			const { signal } = controller;
+
+			signal.addEventListener('abort', () => {
+				enable('.btn-accept, fieldset');
+			}, { once: true });
+
+			try {
+				on('.btn-reject', { click: () => controller.abort() }, { signal, once: true });
+				const integrity = await fromFile(data.get('file'), { algo: data.get('algo') });
+				value('#hash', integrity);
+				enable('#copy-btn');
+				document.getElementById('error-msg').replaceChildren();
+			} catch(err) {
+				disable('#copy-btn');
+				document.getElementById('error-msg').textContent = err;
+				value('#hash', null);
+				console.error(err);
+				document.getElementById('error-dialog').showModal();
+			} finally {
+				if (! controller.signal.aborted) {
+					setTimeout(() => controller.abort(), 500);
+				}
+			}
+		},
+		reset: () => {
+			value('#hash', '');
+			disable('#copy-btn');
+			document.getElementById('error-container').replaceChildren();
+		},
+	});
+
+	enable('fieldset, button[type="submit"], button[type="reset"]');
+});

--- a/test.js
+++ b/test.js
@@ -1,0 +1,5 @@
+try {
+	document.querySelector('#main blockquote').innerHTML = 'hacked!';
+} catch(err) {
+	console.error(err);
+}


### PR DESCRIPTION
Custom element templates are now fetched & parsed using `purify.createHTML()`, which is creates `TrustedHTML` from its `TrustedTypePolicy` (`'purify#html'`).

Most of this work is updates to shgysk8zer0/std-js