### PR TITLE
Revert back to running `npm i`

### DIFF
--- a/netlify.toml
+++ b/netlify.toml
@@ -2,4 +2,4 @@
 [build]
   base = "./"
   publish = "./"
-  command = "npm ci"
+  command = "npm i"


### PR DESCRIPTION
Looks as though `npm ci` doesn't run `postinstall` script.
