### PR TITLE
Update to use `getURLResolver()`

### DIFF
--- a/components/ad/block.js
+++ b/components/ad/block.js
@@ -8,11 +8,13 @@ import { getHTML } from '../../js/std-js/http.js';
 import { meta } from '../../import.meta.js';
 import { getDeferred } from '../../js/std-js/promises.js';
 import UTM from '../../js/std-js/UTM.js';
+import { getURLResolver } from '../../js/std-js/utility.js';
 import { purify as policy } from '../../js/std-js/htmlpurify.js';
 
 const { resolve, promise: def } = getDeferred();
+const resolveURL = getURLResolver({ base: meta.url, path: '/components/ad/' });
 
-const templatePromise = def.then(() => getHTML(new URL('./components/ad/block.html', meta.url), { policy }));
+const templatePromise = def.then(() => getHTML(resolveURL('./block.html'), { policy }));
 
 async function getTemplate() {
 	resolve();
@@ -239,7 +241,7 @@ HTMLCustomElement.register('ad-block', class HTMLAdBlockElement extends HTMLCust
 		Promise.allSettled([
 			this.whenConnected,
 			this.whenLoad,
-			loadStylesheet(new URL('./components/ad/block.css', meta.url), { parent: this.shadowRoot }),
+			loadStylesheet(resolveURL('./block.css'), { parent: this.shadowRoot }),
 		]).then(() => {
 			getTemplate().then(tmp => {
 				tmp.querySelectorAll('slot[name]').forEach(el => {

--- a/components/github/repo.js
+++ b/components/github/repo.js
@@ -5,9 +5,10 @@ import { purify as policy } from '../../js/std-js/htmlpurify.js';
 import { whenIntersecting } from '../../js/std-js/intersect.js';
 import { getDeferred } from '../../js/std-js/promises.js';
 import { registerCustomElement } from '../../js/std-js/custom-elements.js';
+import { getURLResolver } from '../../js/std-js/utility.js';
 import { meta } from '../../import.meta.js';
 
-
+const resolveURL = getURLResolver({ base: meta.url, path: '/components/github/' });
 const symbols = {
 	shadow: Symbol('shadow'),
 	timeout: Symbol('timeout'),
@@ -16,7 +17,7 @@ const symbols = {
 
 const ENDPOINT =  'https://api.github.com/repos/';
 const { resolve, promise: def } = getDeferred();
-const templatePromise = def.then(() => getHTML(new URL('./components/github/repo.html', meta.url), { policy }));
+const templatePromise = def.then(() => getHTML(resolveURL('./repo.html'), { policy }));
 
 async function getTemplate() {
 	resolve();
@@ -111,7 +112,7 @@ registerCustomElement('github-repo', class HTMLGitHubRepoElement extends HTMLEle
 		}
 
 		const tmp = await getTemplate();
-		await loadStylesheet(new URL('./components/github/repo.css', meta.url), { parent: this[symbols.shadow] });
+		await loadStylesheet(resolveURL('./repo.css'), { parent: this[symbols.shadow] });
 		this[symbols.shadow].append(tmp);
 		this.dispatchEvent(new Event('ready'));
 	}

--- a/components/github/user.js
+++ b/components/github/user.js
@@ -5,11 +5,13 @@ import { loadStylesheet } from '../../js/std-js/loader.js';
 import { getDeferred } from '../../js/std-js/promises.js';
 import { purify as policy } from '../../js/std-js/htmlpurify.js';
 import { whenIntersecting } from '../../js/std-js/intersect.js';
+import { getURLResolver } from '../../js/std-js/utility.js';
 
 const ENDPOINT = 'https://api.github.com';
 import HTMLCustomElement from '../custom-element.js';
+const resolveURL = getURLResolver({ base : meta.url, path: '/components/github/' });
 const { resolve, promise: def } = getDeferred();
-const templatePromise = def.then(() => getHTML(new URL('./components/github/user.html', meta.url), { policy }));
+const templatePromise = def.then(() => getHTML(resolveURL('./user.html', meta.url), { policy }));
 
 async function getTemplate() {
 	resolve();
@@ -48,7 +50,7 @@ HTMLCustomElement.register('github-user', class HTMLGitHubUserElement extends HT
 			]).then(() => {
 				Promise.all([
 					getTemplate(),
-					loadStylesheet(new URL('./components/github/user.css', meta.url), { parent: this.shadowRoot }),
+					loadStylesheet(resolveURL('./user.css'), { parent: this.shadowRoot }),
 				]).then(([tmp]) => {
 					this.shadowRoot.append(tmp);
 					this.dispatchEvent(new Event('ready'));

--- a/components/install/prompt.js
+++ b/components/install/prompt.js
@@ -1,5 +1,6 @@
 import { registerCustomElement, getCustomElement } from '../../js/std-js/custom-elements.js';
 import { meta } from '../../import.meta.js';
+import { getURLResolver } from '../../js/std-js/utility.js';
 import { loadStylesheet } from '../../js/std-js/loader.js';
 import { getHTML } from '../../js/std-js/http.js';
 import { query, create, text, on, off } from '../../js/std-js/dom.js';
@@ -11,8 +12,9 @@ const { resolve, promise: def } = getDeferred();
 
 import '../notification/html-notification.js';
 const getManifest = async () => await manifestPromise;
+const resolveURL = getURLResolver({ base: meta.url, path: '/components/install/' });
 
-const templatePromise = def.then(() => getHTML(new URL('./components/install/prompt.html', meta.url), { policy }));
+const templatePromise = def.then(() => getHTML(resolveURL('./prompt.html'), { policy }));
 
 async function getTemplate() {
 	resolve();
@@ -141,7 +143,7 @@ registerCustomElement('install-prompt', class HTMLInstallPromptElement extends H
 		Promise.all([
 			getTemplate(),
 			getManifest(),
-			loadStylesheet(new URL('./components/install/prompt.css', meta.url), { parent: shadow }),
+			loadStylesheet(resolveURL('./prompt.css'), { parent: shadow }),
 		]).then(async ([base, manifest]) => {
 			/**
 			 * @TODO: Handle `prefer_related_applications` somehow

--- a/components/krv/contact.js
+++ b/components/krv/contact.js
@@ -3,9 +3,11 @@ import { on } from '../../js/std-js/dom.js';
 import { loadStylesheet } from '../../js/std-js/loader.js';
 import { getHTML } from '../../js/std-js/http.js';
 import { meta } from '../../import.meta.js';
+import { getURLResolver } from '../../js/std-js/utility.js';
 import { send } from '../../js/std-js/slack.js';
 import { whenIntersecting } from '../../js/std-js/intersect.js';
 const ENDPOINT = 'https://contact.kernvalley.us/api/slack';
+const resolveURL = getURLResolver({ base: meta.url, path: '/components/krv/' });
 
 const symbols = {
 	shadow: Symbol('shadow'),
@@ -20,8 +22,8 @@ registerCustomElement('krv-contact', class HTMLKRVContactElement extends HTMLEle
 
 		whenIntersecting(this).then(async () => {
 			const [tmp] = await Promise.all([
-				getHTML(new URL('./components/krv/contact.html', meta.url).href),
-				loadStylesheet(new URL('./components/krv/contact.css', meta.url).href, { parent: shadow }),
+				getHTML(resolveURL('./contact.html')),
+				loadStylesheet(resolveURL('./contact.css'), { parent: shadow }),
 				loadStylesheet('https://cdn.kernvalley.us/css/core-css/forms.css', { parent: shadow }),
 				whenIntersecting(this),
 			]);

--- a/components/krv/events.js
+++ b/components/krv/events.js
@@ -4,12 +4,14 @@ import { registerCustomElement } from '../../js/std-js/custom-elements.js';
 import { loadStylesheet } from '../../js/std-js/loader.js';
 import { hasGa, send } from '../../js/std-js/google-analytics.js';
 import { meta } from '../../import.meta.js';
+import { getURLResolver } from '../../js/std-js/utility.js';
 import { getDeferred } from '../../js/std-js/promises.js';
 import { purify as policy } from '../../js/std-js/htmlpurify.js';
 import { whenIntersecting } from '../../js/std-js/intersect.js';
 
 const { resolve, promise: def } = getDeferred();
-const templatePromise = def.then(() => getHTML(new URL('./components/krv/events.html', meta.url), { policy }));
+const resolveURL = getURLResolver({ base: meta.url, path: '/components/krv/' });
+const templatePromise = def.then(() => getHTML(resolveURL('./events.html'), { policy }));
 
 async function getTemplate() {
 	resolve();
@@ -54,7 +56,7 @@ registerCustomElement('krv-events', class HTMLKRVEventsElement extends HTMLEleme
 
 		Promise.all([
 			getTemplate(),
-			loadStylesheet(new URL('./components/krv/events.css', meta.url).href, { parent }),
+			loadStylesheet(resolveURL('./events.css'), { parent }),
 			this.whenConnected,
 		]).then(([frag]) => {
 			const link = frag.querySelector('.app-link');

--- a/components/leaflet/map.js
+++ b/components/leaflet/map.js
@@ -1,4 +1,4 @@
-import { meta } from '../../../import.meta.js';
+import { meta } from '../../import.meta.js';
 import { debounce } from '../../js/std-js/utility.js';
 import { get as getLocation } from '../../js/std-js/geo.js';
 import { on, off, create, query } from '../../js/std-js/dom.js';

--- a/components/leaflet/map.js
+++ b/components/leaflet/map.js
@@ -1,9 +1,11 @@
+import { meta } from '../../../import.meta.js';
 import { debounce } from '../../js/std-js/utility.js';
 import { get as getLocation } from '../../js/std-js/geo.js';
 import { on, off, create, query } from '../../js/std-js/dom.js';
 import { loadStylesheet } from '../../js/std-js/loader.js';
 import { between } from '../../js/std-js/math.js';
 import { getCustomElement } from '../../js/std-js/custom-elements.js';
+import { getURLResolver } from '../../js/std-js/utility.js';
 import HTMLCustomElement from '../custom-element.js';
 import { MARKER_TYPES } from './marker-types.js';
 import { TILES } from './tiles.js';
@@ -16,6 +18,7 @@ import {
 
 const initialTitle = document.title;
 const GEO_EXP = /#-?\d{1,3}\.\d+,-?\d{1,3}\.\d+(,\d{1,2})?/;
+const resolveURL = getURLResolver({ base: meta.url, path: '/components/leaflet/' });
 
 let data = new WeakMap();
 
@@ -304,9 +307,7 @@ HTMLCustomElement.register('leaflet-map', class HTMLLeafletMapElement extends HT
 					integrity: 'sha512-hoalWLoI8r4UszCkZ5kL8vayOGVae1oxXe/2A4AO6J9+580uKHDO3JdHb7NzwwzK5xr/Fs0W40kiNHxM9vyTtQ==',
 					parent: this._shadow,
 				}),
-				loadStylesheet(new URL('./components/leaflet/map.css', HTMLCustomElement.base), {
-					parent: this._shadow,
-				}),
+				loadStylesheet(resolveURL('./map.css'), { parent: this._shadow }),
 			]);
 
 			requestAnimationFrame(async () => {

--- a/components/pwa/prompt.js
+++ b/components/pwa/prompt.js
@@ -2,11 +2,13 @@ import HTMLCustomElement from '../custom-element.js';
 import { registerButton } from '../../js/pwa-install.js';
 import { getHTML } from '../../js/std-js/http.js';
 import { meta } from '../../import.meta.js';
+import { getURLResolver } from '../../js/std-js/utility.js';
 import { getDeferred } from '../../js/std-js/promises.js';
 import { purify as policy } from '../../js/std-js/htmlpurify.js';
-const { resolve, promise: def } = getDeferred();
 
-const templatePromise = def.then(() => getHTML(new URL('./components/pwa/prompt.html', meta.url),  { policy }));
+const { resolve, promise: def } = getDeferred();
+const resolveURL = getURLResolver({ base: meta.url, path: '/components/pwa/' });
+const templatePromise = def.then(() => getHTML(resolveURL('./prompt.html'),  { policy }));
 
 async function getTemplate() {
 	resolve();

--- a/components/share-to-button/share-to-button.js
+++ b/components/share-to-button/share-to-button.js
@@ -3,6 +3,7 @@ import { hasGa, send } from '../../js/std-js/google-analytics.js';
 import { popup } from '../../js/std-js/popup.js';
 import { getHTML } from '../../js/std-js/http.js';
 import { meta } from '../../import.meta.js';
+import { getURLResolver } from '../../js/std-js/utility.js';
 import { getDeferred } from '../../js/std-js/promises.js';
 import { loadStylesheet } from '../../js/std-js/loader.js';
 import { Facebook, Twitter, Reddit, LinkedIn, Gmail, Pinterest, Email, Tumblr, Telegram, getShareURL }
@@ -10,8 +11,9 @@ import { Facebook, Twitter, Reddit, LinkedIn, Gmail, Pinterest, Email, Tumblr, T
 
 import { purify as policy } from '../../js/std-js/htmlpurify.js';
 const { resolve, promise: def } = getDeferred();
+const resolveURL = getURLResolver({ base: meta.url, path: '/components/share-to-button/' });
 
-const templatePromise = def.then(() => getHTML(new URL('./components/share-to-button/share-to-button.html', meta.url), { policy }));
+const templatePromise = def.then(() => getHTML(resolveURL('./share-to-button.html'), { policy }));
 
 async function getTemplate() {
 	resolve();
@@ -131,7 +133,7 @@ HTMLCustomElement.register('share-to-button', class HTMLShareToButtonElement ext
 			}
 			this.shadowRoot.append(tmp);
 
-			loadStylesheet(new URL('./components/share-to-button/share-to-button.css', meta.url), { parent: this.shadowRoot }).then(() => {
+			loadStylesheet(resolveURL('./share-to-button.css'), { parent: this.shadowRoot }).then(() => {
 				this.dispatchEvent(new Event('ready'));
 				this.hidden = wasHidden;
 			});

--- a/components/weather/forecast.js
+++ b/components/weather/forecast.js
@@ -3,11 +3,13 @@ import {shadows, clearSlot, clearSlots, getForecastByPostalCode, createIcon, get
 import HTMLCustomElement from '../custom-element.js';
 import { purify as policy } from '../../js/std-js/htmlpurify.js';
 import { getHTML } from '../../js/std-js/http.js';
+import { getURLResolver } from '../../js/std-js/utility.js';
+
+const resolveURL = getURLResolver({ base: meta.url, path: '/components/weather/' });
 
 async function getTemplate() {
-	const url = new URL('./components/weather/forecast.html', meta.url);
-	const tmp = await getHTML(url, { policy });
-	tmp.querySelectorAll('link[href]').forEach(link => link.href = new URL(link.getAttribute('href'), url.href));
+	const tmp = await getHTML(resolveURL('./forecast.html'), { policy });
+	tmp.querySelectorAll('link[href]').forEach(link => link.href = resolveURL(link.getAttribute('href')));
 	return tmp;
 }
 


### PR DESCRIPTION
Makes working with relative URLs easier, given the lack of `import.meta.url` & `import.meta.resolve()` after running through RollUp.
