### PR TITLE
Switch from `func.once()` to `callOnce(func)`

### DIFF
--- a/components/github/repo.js
+++ b/components/github/repo.js
@@ -5,7 +5,7 @@ import { purify as policy } from '../../js/std-js/htmlpurify.js';
 import { whenIntersecting } from '../../js/std-js/intersect.js';
 import { getDeferred } from '../../js/std-js/promises.js';
 import { registerCustomElement } from '../../js/std-js/custom-elements.js';
-import { getURLResolver } from '../../js/std-js/utility.js';
+import { getURLResolver, callOnce } from '../../js/std-js/utility.js';
 import { meta } from '../../import.meta.js';
 import { getString, setString } from '../../js/std-js/attrs.js';
 
@@ -18,7 +18,7 @@ const symbols = {
 
 const ENDPOINT =  'https://api.github.com/repos/';
 
-const getTemplate = (() => getHTML(resolveURL('./repo.html'), { policy })).once();
+const getTemplate = callOnce(() => getHTML(resolveURL('./repo.html'), { policy }));
 
 async function getJSON(url, { signal } = {}) {
 	const key = `github-repo:${url}`;

--- a/components/github/user.js
+++ b/components/github/user.js
@@ -5,13 +5,13 @@ import { loadStylesheet } from '../../js/std-js/loader.js';
 import { getDeferred } from '../../js/std-js/promises.js';
 import { purify as policy } from '../../js/std-js/htmlpurify.js';
 import { whenIntersecting } from '../../js/std-js/intersect.js';
-import { getURLResolver } from '../../js/std-js/utility.js';
+import { getURLResolver, callOnce } from '../../js/std-js/utility.js';
 import { getString, setString, getBool, setBool } from '../../js/std-js/attrs.js';
 
 const ENDPOINT = 'https://api.github.com';
 import HTMLCustomElement from '../custom-element.js';
 const resolveURL = getURLResolver({ base : meta.url, path: '/components/github/' });
-const getTemplate = (() => getHTML(resolveURL('./user.html', meta.url), { policy })).once();
+const getTemplate = callOnce(() => getHTML(resolveURL('./user.html', meta.url), { policy }));
 async function getUser(user) {
 	const key = `github-user-${user}`;
 

--- a/components/krv/contact.js
+++ b/components/krv/contact.js
@@ -3,11 +3,12 @@ import { on } from '../../js/std-js/dom.js';
 import { loadStylesheet } from '../../js/std-js/loader.js';
 import { getHTML } from '../../js/std-js/http.js';
 import { meta } from '../../import.meta.js';
-import { getURLResolver } from '../../js/std-js/utility.js';
+import { getURLResolver, callOnce } from '../../js/std-js/utility.js';
 import { send } from '../../js/std-js/slack.js';
 import { whenIntersecting } from '../../js/std-js/intersect.js';
 const ENDPOINT = 'https://contact.kernvalley.us/api/slack';
 const resolveURL = getURLResolver({ base: meta.url, path: '/components/krv/' });
+const getTemplate = callOnce(() => getHTML(resolveURL('./contact.html')));
 
 const symbols = {
 	shadow: Symbol('shadow'),
@@ -22,7 +23,7 @@ registerCustomElement('krv-contact', class HTMLKRVContactElement extends HTMLEle
 
 		whenIntersecting(this).then(async () => {
 			const [tmp] = await Promise.all([
-				getHTML(resolveURL('./contact.html')),
+				getTemplate().then(tmp => tmp.cloneNode(true)),
 				loadStylesheet(resolveURL('./contact.css'), { parent: shadow }),
 				loadStylesheet('https://cdn.kernvalley.us/css/core-css/forms.css', { parent: shadow }),
 				whenIntersecting(this),

--- a/components/krv/events.js
+++ b/components/krv/events.js
@@ -5,13 +5,13 @@ import { registerCustomElement } from '../../js/std-js/custom-elements.js';
 import { loadStylesheet } from '../../js/std-js/loader.js';
 import { hasGa, send } from '../../js/std-js/google-analytics.js';
 import { meta } from '../../import.meta.js';
-import { getURLResolver } from '../../js/std-js/utility.js';
+import { getURLResolver, callOnce } from '../../js/std-js/utility.js';
 import { purify as policy } from '../../js/std-js/htmlpurify.js';
 import { whenIntersecting } from '../../js/std-js/intersect.js';
 import { getString, setString, getInt, setInt } from '../../js/std-js/attrs.js';
 
 const resolveURL = getURLResolver({ base: meta.url, path: '/components/krv/' });
-const getTemplate = (() => getHTML(resolveURL('events.html'), { policy })).once();
+const getTemplate = callOnce(() => getHTML(resolveURL('events.html'), { policy }));
 const getEvents = (() => getAllEvents()).once();
 const protectedData = new WeakMap();
 

--- a/components/pwa/prompt.js
+++ b/components/pwa/prompt.js
@@ -2,11 +2,11 @@ import HTMLCustomElement from '../custom-element.js';
 import { registerButton } from '../../js/pwa-install.js';
 import { getHTML } from '../../js/std-js/http.js';
 import { meta } from '../../import.meta.js';
-import { getURLResolver } from '../../js/std-js/utility.js';
+import { getURLResolver, callOnce } from '../../js/std-js/utility.js';
 import { purify as policy } from '../../js/std-js/htmlpurify.js';
 
 const resolveURL = getURLResolver({ base: meta.url, path: '/components/pwa/' });
-const getTemplate = (() => getHTML(resolveURL('./prompt.html'),  { policy })).once();
+const getTemplate = callOnce(() => getHTML(resolveURL('./prompt.html'),  { policy }));
 
 function getBySize(opts, width) {
 	if (Array.isArray(opts)) {

--- a/components/share-to-button/share-to-button.js
+++ b/components/share-to-button/share-to-button.js
@@ -3,7 +3,7 @@ import { hasGa, send } from '../../js/std-js/google-analytics.js';
 import { popup } from '../../js/std-js/popup.js';
 import { getHTML } from '../../js/std-js/http.js';
 import { meta } from '../../import.meta.js';
-import { getURLResolver } from '../../js/std-js/utility.js';
+import { getURLResolver, callOnce } from '../../js/std-js/utility.js';
 import { loadStylesheet } from '../../js/std-js/loader.js';
 import { getString, setString, getBool, setBool, getURL, setURL } from '../../js/std-js/attrs.js';
 import { setUTMParams } from '../../js/std-js/utility.js';
@@ -14,7 +14,7 @@ import { purify as policy } from '../../js/std-js/htmlpurify.js';
 const resolveURL = getURLResolver({ base: meta.url, path: '/components/share-to-button/' });
 
 
-const getTemplate = (() => getHTML(resolveURL('./share-to-button.html'), { policy })).once();
+const getTemplate = callOnce(() => getHTML(resolveURL('./share-to-button.html'), { policy }));
 
 function log(btn) {
 	if (hasGa()) {

--- a/components/spotify/player.js
+++ b/components/spotify/player.js
@@ -4,14 +4,14 @@ import { whenIntersecting } from '../../js/std-js/intersect.js';
 import { purify as policy } from '../../js/std-js/htmlpurify.js';
 import { loaded } from '../../js/std-js/events.js';
 import { getHTML } from '../../js/std-js/http.js';
-import { getURLResolver } from '../../js/std-js/utility.js';
+import { getURLResolver, callOnce } from '../../js/std-js/utility.js';
 import { meta } from '../../import.meta.js';
 import { loadStylesheet } from '../../js/std-js/loader.js';
 import { getBool, setBool, getString, setString } from '../../js/std-js/attrs.js';
 
 const protectedData = new WeakMap();
 const resolveURL = getURLResolver({ path: '/components/spotify/', base: meta.url });
-const getTemplate = (() => getHTML(resolveURL('./player.html'), { policy })).once();
+const getTemplate = callOnce(() => getHTML(resolveURL('./player.html'), { policy }));
 
 const SPOTIFY = 'https://open.spotify.com/embed/';
 const TYPES = [

--- a/components/wfd/events.js
+++ b/components/wfd/events.js
@@ -5,7 +5,7 @@ import { whenIntersecting } from '../../js/std-js/intersect.js';
 import { text, attr } from '../../js/std-js/dom.js';
 import { days } from '../../js/std-js/date-consts.js';
 import { getHTML } from '../../js/std-js/http.js';
-import { getURLResolver, setUTMParams } from '../../js/std-js/utility.js';
+import { getURLResolver, setUTMParams, callOnce } from '../../js/std-js/utility.js';
 import { meta } from '../../import.meta.js';
 import { loadStylesheet } from '../../js/std-js/loader.js';
 import { purify as policy } from '../../js/std-js/htmlpurify.js';
@@ -17,8 +17,8 @@ const medium = 'referral';
 const content = 'wfd-events';
 const sanitizer = new Sanitizer();
 const resolveURL = getURLResolver({ base : meta.url, path: '/components/wfd/' });
-const getTemplate = (() => getHTML(resolveURL('events.html'), { policy })).once();
-const getEvents = (() => getAllEvents()).once();
+const getTemplate = callOnce(() => getHTML(resolveURL('events.html'), { policy }));
+const getEvents = callOnce(() => getAllEvents());
 
 function getWFDLink(path, params) {
 	return setUTMParams(new URL(path, WFD), params);


### PR DESCRIPTION
The proposal for `func.once()` is only stage 1 and may change to a static method. It may also create race conditions if the shim is not yet loaded.
