### PR TITLE
Update `createHTML` in default policy

### DIFF
--- a/js/default-trust-policy.js
+++ b/js/default-trust-policy.js
@@ -10,7 +10,11 @@ const trustedOrigins = [
 export const sanitizer = new globalThis.Sanitizer(config);
 
 export const defaultPolicy = createPolicy('default', {
-	createHTML: input => sanitizer.sanitizeFor('div', input).innerHTML,
+	createHTML: input => {
+		const el = document.createElement('div');
+		el.setHTML(input, { sanitizer });
+		return el.innerHTML;
+	},
 	createScript: () => '',
 	createScriptURL: input => {
 		if (trustedOrigins.includes(new URL(input, document.baseURI).origin)) {


### PR DESCRIPTION
Turns out `sanitize.sanitizeFor` isn't supported in Chrome, and polyfill may be slow to apply. `el.setHTML` is better supported.

# Description and issue

> Please add relevant sections (Added, removed, changed, fixed) to `CHANGELOG.md`

## List of significant changes made
-  
-  
