### PR TITLE
More `TrustedTypes` support

### DIFF
--- a/_headers
+++ b/_headers
@@ -4,7 +4,7 @@
   Referrer-Policy: no-referrer
   Link: </js/shims.min.js>; rel=preload; as=script; referrerpolicy=no-referrrer;
   Link: </js/security.min.js>; rel=preload; as=script; referrerpolicy=no-referrrer;
-  Content-Security-Policy: default-src 'self'; style-src 'self' cdn.kernvalley.us unpkg.com; script-src 'self' cdn.kernvalley.us unpkg.com www.gstatic.com/firebasejs/ gist.github.com; connect-src 'self' *.kernvalley.us api.github.com api.openweathermap.org/data/ baconipsum.com/api/ whiskeyflatdays.com; img-src * data: blob:; media-src 'none'; font-src 'self' cdn.kernvalley.us; upgrade-insecure-requests; trusted-types default empty#html empty#script sanitizer-raw#html purify-raw#html purify#html github#gist dompurify share-to-buttons#html weather-current#html weather-forecast#html krv-events#html codepen#script-url module#script-url purify-raw#html purify#html; require-trusted-types-for 'script';
+  Content-Security-Policy: default-src 'self'; style-src 'self' cdn.kernvalley.us unpkg.com; script-src 'self' cdn.kernvalley.us unpkg.com www.gstatic.com/firebasejs/ gist.github.com; connect-src 'self' *.kernvalley.us api.github.com api.openweathermap.org/data/ baconipsum.com/api/ whiskeyflatdays.com; img-src * data: blob:; media-src 'none'; font-src 'self' cdn.kernvalley.us; upgrade-insecure-requests; trusted-types default empty#html empty#script sanitizer-raw#html purify-raw#html purify#html github#gist dompurify share-to-buttons#html weather-current#html weather-forecast#html krv-events#html codepen#script-url module#script-url purify-raw#html purify#html pwa-install html-notification#script; require-trusted-types-for 'script';
 
 /convert/
   X-Frame-Options: DENY

--- a/_headers
+++ b/_headers
@@ -4,7 +4,7 @@
   Referrer-Policy: no-referrer
   Link: </js/shims.min.js>; rel=preload; as=script; referrerpolicy=no-referrrer;
   Link: </js/security.min.js>; rel=preload; as=script; referrerpolicy=no-referrrer;
-  Content-Security-Policy: default-src 'self'; style-src 'self' cdn.kernvalley.us unpkg.com; script-src 'self' cdn.kernvalley.us unpkg.com www.gstatic.com/firebasejs/ gist.github.com; connect-src 'self' *.kernvalley.us api.github.com api.openweathermap.org/data/ baconipsum.com/api/ whiskeyflatdays.com; img-src * data: blob:; media-src 'none'; font-src 'self' cdn.kernvalley.us; upgrade-insecure-requests; trusted-types default empty#html empty#script sanitizer-raw#html purify-raw#html purify#html github#gist dompurify share-to-buttons#html weather-current#html weather-forecast#html krv-events#html codepen#script-url module#script-url purify-raw#html purify#html pwa-install html-notification#script; require-trusted-types-for 'script';
+  Content-Security-Policy: default-src 'self'; style-src 'self' cdn.kernvalley.us unpkg.com; script-src 'self' cdn.kernvalley.us unpkg.com www.gstatic.com/firebasejs/ gist.github.com; connect-src 'self' *.kernvalley.us api.github.com api.openweathermap.org/data/ baconipsum.com/api/ whiskeyflatdays.com; img-src * data: blob:; media-src 'none'; font-src 'self' cdn.kernvalley.us; frame-src open.spotify.com/embed/ www.youtube.com/embed/ www.youtube-nocookie.com/embed/; upgrade-insecure-requests; trusted-types default empty#html empty#script sanitizer-raw#html purify-raw#html purify#html github#gist dompurify share-to-buttons#html weather-current#html weather-forecast#html krv-events#html codepen#script-url module#script-url purify-raw#html purify#html pwa-install html-notification#script spotify-player; require-trusted-types-for 'script';
 
 /convert/
   X-Frame-Options: DENY
@@ -39,5 +39,6 @@
   Access-Control-Allow-Methods: GET, HEAD, OPTIONS
   X-Content-Type-Options: nosniff
   Tk: N
+
 
 

--- a/components/install/prompt.js
+++ b/components/install/prompt.js
@@ -1,15 +1,14 @@
-import { registerCustomElement, getCustomElement } from '../../js/std-js/custom-elements.js';
+import { registerCustomElement } from '../../js/std-js/custom-elements.js';
 import { meta } from '../../import.meta.js';
 import { getURLResolver } from '../../js/std-js/utility.js';
 import { loadStylesheet } from '../../js/std-js/loader.js';
 import { getHTML } from '../../js/std-js/http.js';
-import { loaded } from '../../js/std-js/dom.js';
 import { query, create, text, on, off } from '../../js/std-js/dom.js';
 import { hasGa, send } from '../../js/std-js/google-analytics.js';
 import { registerButton } from '../../js/std-js/pwa-install.js';
 import { createPolicy } from '../../js/std-js/trust.js';
 import { getManifest } from '../../js/std-js/http.js';
-import { callOnce } from '../../js/std-js/utility.js';
+import { callOnce, autoServiceWorkerRegistration } from '../../js/std-js/utility.js';
 import '../notification/html-notification.js';
 
 const policy = createPolicy('pwa-install', {
@@ -102,48 +101,8 @@ function getIcon(...icons) {
 }
 
 if ('serviceWorker' in navigator && 'serviceWorker' in document.documentElement.dataset) {
-	loaded().then(() => {
-		const { serviceWorker, scope = '/' } = document.documentElement.dataset;
-		if ('trustedTypes' in globalThis && trustedTypes.defaultPolicy !== null) {
-			navigator.serviceWorker.register(trustedTypes.defaultPolicy.createScriptURL(serviceWorker), { scope }).catch(console.error);
-		} else {
-			navigator.serviceWorker.register(serviceWorker, { scope }).catch(console.error);
-		}
-	});
-
-	if ('reloadOnUpdate' in document.documentElement.dataset) {
-		navigator.serviceWorker.ready.then(reg => {
-			reg.addEventListener('updatefound', ({ target }) => {
-				target.update();
-				getCustomElement('html-notification').then(HTMLNotificationElement => {
-					const notification = new HTMLNotificationElement('Update available', {
-						body: 'App updated in background. Would you like to reload to see updates?',
-						requireInteraction: true,
-						actions: [{
-							title: 'Reload',
-							action: 'reload',
-						}, {
-							title: 'Dismiss',
-							action: 'dismiss',
-						}]
-					});
-
-					notification.addEventListener('notificationclick', ({ target, action }) => {
-						switch(action) {
-							case 'dismiss':
-								target.close();
-								break;
-
-							case 'reload':
-								target.close();
-								location.reload();
-								break;
-						}
-					});
-				});
-			});
-		});
-	}
+	console.warn('Installing service workers via <install-prompt> is deprecated and will be removed.');
+	autoServiceWorkerRegistration({ policy });
 }
 
 registerCustomElement('install-prompt', class HTMLInstallPromptElement extends HTMLElement {

--- a/components/pwa/install.js
+++ b/components/pwa/install.js
@@ -3,6 +3,7 @@ import { confirm } from '../../js/std-js/asyncDialog.js';
 import { registerCustomElement } from '../../js/std-js/custom-elements.js';
 import { manifestPromise } from '../../js/std-js/promises.js';
 import { hasGa, send } from '../../js/std-js/google-analytics.js';
+import { ready } from '../../js/std-js/dom.js';
 import { getString, setString, getURL, setURL, getBool, setBool } from '../../js/std-js/attrs.js';
 const getManifest = async () => manifestPromise;
 
@@ -131,7 +132,7 @@ registerCustomElement('pwa-install', class HTMLPWAInstallButton extends HTMLButt
 					});
 					resolve(reg);
 				} else {
-					await Promise.all([this.ready, this.whenConnected]);
+					await Promise.all([this.ready, this.whenConnected, ready()]);
 					const reg = await navigator.serviceWorker.register(this.src, {scope: this.scope});
 					this.dispatchEvent(new CustomEvent('serviceworkerinstall', {detail: reg}));
 					resolve(reg);

--- a/components/pwa/prompt.js
+++ b/components/pwa/prompt.js
@@ -6,7 +6,10 @@ import { getURLResolver, callOnce } from '../../js/std-js/utility.js';
 import { purify as policy } from '../../js/std-js/htmlpurify.js';
 
 const resolveURL = getURLResolver({ base: meta.url, path: '/components/pwa/' });
-const getTemplate = callOnce(() => getHTML(resolveURL('./prompt.html'),  { policy }));
+const getTemplate = callOnce(() => getHTML(resolveURL('./prompt.html'), {
+	policy,
+	// integrity: 'sha384-zS8v7FQoAGePrBa0yKrCmjfNijXh4RPZi3XTOV71Yk3HvRZHeGmMi7lCiahio4xY',
+}));
 
 function getBySize(opts, width) {
 	if (Array.isArray(opts)) {

--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" dir="ltr" data-layout="right-sidebar" data-theme="auto" data-trusted-policies="default empty#html empty#script sanitizer-raw#html purify-raw#html purify#html github#gist dompurify share-to-buttons#html weather-current#html weather-forecast#html codepen#script-url krv-events#html module#script-url disqus#script-url" data-fetch-trust-csp="1">
+<html lang="en" dir="ltr" data-layout="right-sidebar" data-theme="auto" data-trusted-policies="default empty#html empty#script sanitizer-raw#html purify-raw#html purify#html github#gist dompurify share-to-buttons#html weather-current#html weather-forecast#html codepen#script-url krv-events#html module#script-url disqus#script-url pwa-install html-notification#script">
 	<head>
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width" />

--- a/index.html
+++ b/index.html
@@ -1,5 +1,5 @@
 <!DOCTYPE html>
-<html lang="en" dir="ltr" data-layout="right-sidebar" data-theme="auto" data-trusted-policies="default empty#html empty#script sanitizer-raw#html purify-raw#html purify#html github#gist dompurify share-to-buttons#html weather-current#html weather-forecast#html codepen#script-url krv-events#html module#script-url disqus#script-url pwa-install html-notification#script">
+<html lang="en" dir="ltr" data-layout="right-sidebar" data-theme="auto" data-trusted-policies="default empty#html empty#script sanitizer-raw#html purify-raw#html purify#html github#gist dompurify share-to-buttons#html weather-current#html weather-forecast#html codepen#script-url krv-events#html module#script-url disqus#script-url pwa-install html-notification#script spotify-player">
 	<head>
 		<meta charset="utf-8" />
 		<meta name="viewport" content="width=device-width" />

--- a/index.js
+++ b/index.js
@@ -8,8 +8,6 @@ import '/components/install/prompt.js';
 
 getDefaultPolicy();
 
-customElements.whenDefined('install-prompt').then(Prompt => new Prompt().show());
-
 const policy = createPolicy('module#script-url', {
 	createScriptURL: input => {
 		const url = new URL(input, document.baseURI);

--- a/index.js
+++ b/index.js
@@ -3,8 +3,12 @@ import { loadScript } from './js/std-js/loader.js';
 import { konami } from '/js/konami/konami.js';
 import { getDefaultPolicy } from '/js/std-js/trust-policies.js';
 import { createPolicy } from '/js/std-js/trust.js';
+import { alert } from '/js/std-js/asyncDialog.js';
+import '/components/install/prompt.js';
 
 getDefaultPolicy();
+
+customElements.whenDefined('install-prompt').then(Prompt => new Prompt().show());
 
 const policy = createPolicy('module#script-url', {
 	createScriptURL: input => {
@@ -82,7 +86,7 @@ const modules = [
 	// './components/leaflet/marker.js',
 	'./components/app/list-button.js',
 	'./components/app/stores.js',
-	'./components/notification/html-notification.js',
+	// './components/notification/html-notification.js',
 	'./js/std-js/theme-cookie.js',
 	'./components/krv/ad.js',
 	'./components/loading-spinner.js',


### PR DESCRIPTION
- Use `TrustedScriptURL` in `<install-prompt>`
- More custom elements create trust policies where necessary
- Update CSP
- Construct rather than import template for `<html-notification>`
- Use `TrustedScriptURL` in `<spotify-player>`
- Misc other updates